### PR TITLE
Some useful administrative scripts. 

### DIFF
--- a/tools/build-debug.sh
+++ b/tools/build-debug.sh
@@ -1,0 +1,1 @@
+msbuild /t:Build /p:AllowUnsafeBlocks=true /p:Configuration=Debug

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,0 +1,1 @@
+msbuild /t:Build  /p:AllowUnsafeBlocks=true /p:Configuration=Release

--- a/tools/pack.sh
+++ b/tools/pack.sh
@@ -1,0 +1,7 @@
+# Build a tarball for the build, excluding various development directories.  This command should be run in the top 
+# level of the source tree and passed a name to be used for the release. This name is used to generate the tar file
+# and is currently placed in the directory above where the command is run.
+
+releasename=$1
+
+tar --exclude='./.git' --exclude='./.nant' --exclude='./.vs' --exclude='./.vscode' --exclude='bin/ScriptEngines'  -czvf ../${releasename}.tar.gz .


### PR DESCRIPTION
Used to generate Debug or Release builds using msbuild and to pack a build for release skipping some development specific files.
These should generally be run from the top level of the source tree.