### PR TITLE
Don't enable unsafe code unless it's absolutely needed.

### DIFF
--- a/OpenSim/Addons/Groups/OpenSim.Addons.Groups.csproj
+++ b/OpenSim/Addons/Groups/OpenSim.Addons.Groups.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Addons.Groups</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="OpenSim.Addons.Groups.addin.xml" />

--- a/OpenSim/Addons/OfflineIM/OpenSim.Addons.OfflineIM.csproj
+++ b/OpenSim/Addons/OfflineIM/OpenSim.Addons.OfflineIM.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Addons.OfflineIM</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MySql.Data" Version="8.0.25" />

--- a/OpenSim/ApplicationPlugins/LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
+++ b/OpenSim/ApplicationPlugins/LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright � OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/ApplicationPlugins/RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
+++ b/OpenSim/ApplicationPlugins/RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/ApplicationPlugins/RemoteController/OpenSim.ApplicationPlugins.RemoteController.csproj
+++ b/OpenSim/ApplicationPlugins/RemoteController/OpenSim.ApplicationPlugins.RemoteController.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright OpenSimulator developers ©  2012</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.Tests.csproj
+++ b/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenId">

--- a/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.csproj
+++ b/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenId">

--- a/OpenSim/Capabilities/OpenSim.Capabilities.csproj
+++ b/OpenSim/Capabilities/OpenSim.Capabilities.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/ConsoleClient/OpenSim.ConsoleClient.csproj
+++ b/OpenSim/ConsoleClient/OpenSim.ConsoleClient.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/MySQL/OpenSim.Data.MySQL.csproj
+++ b/OpenSim/Data/MySQL/OpenSim.Data.MySQL.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.MySQL</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/Null/OpenSim.Data.Null.csproj
+++ b/OpenSim/Data/Null/OpenSim.Data.Null.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.Null</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/OpenSim.Data.csproj
+++ b/OpenSim/Data/OpenSim.Data.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/PGSQL/OpenSim.Data.PGSQL.csproj
+++ b/OpenSim/Data/PGSQL/OpenSim.Data.PGSQL.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.PGSQL</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/SQLite/OpenSim.Data.SQLite.csproj
+++ b/OpenSim/Data/SQLite/OpenSim.Data.SQLite.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.SQLite</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers 2007-2009</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Data/Tests/OpenSim.Data.Tests.csproj
+++ b/OpenSim/Data/Tests/OpenSim.Data.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/AssetLoader/Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
+++ b/OpenSim/Framework/AssetLoader/Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
+++ b/OpenSim/Framework/Console/OpenSim.Framework.Console.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>ServerConsole</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Monitoring/OpenSim.Framework.Monitoring.csproj
+++ b/OpenSim/Framework/Monitoring/OpenSim.Framework.Monitoring.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Serialization/OpenSim.Framework.Serialization.csproj
+++ b/OpenSim/Framework/Serialization/OpenSim.Framework.Serialization.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Serialization/Tests/OpenSim.Framework.Serialization.Tests.csproj
+++ b/OpenSim/Framework/Serialization/Tests/OpenSim.Framework.Serialization.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Servers/HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
+++ b/OpenSim/Framework/Servers/HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Servers/OpenSim.Framework.Servers.csproj
+++ b/OpenSim/Framework/Servers/OpenSim.Framework.Servers.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Servers/Tests/OpenSim.Framework.Servers.Tests.csproj
+++ b/OpenSim/Framework/Servers/Tests/OpenSim.Framework.Servers.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Framework/Tests/OpenSim.Framework.Tests.csproj
+++ b/OpenSim/Framework/Tests/OpenSim.Framework.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nini">

--- a/OpenSim/Region/Application/OpenSim.csproj
+++ b/OpenSim/Region/Application/OpenSim.csproj
@@ -7,7 +7,6 @@
     <Product>OpenSim</Product>
     <Description>The executable for regions simulator</Description>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ClientStack/Linden/Caps/OpenSim.Region.ClientStack.LindenCaps.Tests.csproj
+++ b/OpenSim/Region/ClientStack/Linden/Caps/OpenSim.Region.ClientStack.LindenCaps.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ClientStack/Linden/Caps/OpenSim.Region.ClientStack.LindenCaps.csproj
+++ b/OpenSim/Region/ClientStack/Linden/Caps/OpenSim.Region.ClientStack.LindenCaps.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ClientStack/Linden/UDP/Tests/OpenSim.Region.ClientStack.LindenUDP.Tests.csproj
+++ b/OpenSim/Region/ClientStack/Linden/UDP/Tests/OpenSim.Region.ClientStack.LindenUDP.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.Tests.csproj
+++ b/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenMail">

--- a/OpenSim/Region/Framework/OpenSim.Region.Framework.Tests.csproj
+++ b/OpenSim/Region/Framework/OpenSim.Region.Framework.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenMail">

--- a/OpenSim/Region/OptionalModules/OpenSim.Region.OptionalModules.csproj
+++ b/OpenSim/Region/OptionalModules/OpenSim.Region.OptionalModules.csproj
@@ -5,7 +5,6 @@
     <Product>OpenSim.Region.OptionalModules.Properties</Product>
     <Description>Optional modules for OpenSim</Description>
     <Copyright>Copyright ©  2012</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenMail">

--- a/OpenSim/Region/PhysicsModules/BasicPhysics/OpenSim.Region.PhysicsModule.BasicPhysics.csproj
+++ b/OpenSim/Region/PhysicsModules/BasicPhysics/OpenSim.Region.PhysicsModule.BasicPhysics.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Addins">

--- a/OpenSim/Region/PhysicsModules/BulletS/OpenSim.Region.PhysicsModule.BulletS.csproj
+++ b/OpenSim/Region/PhysicsModules/BulletS/OpenSim.Region.PhysicsModule.BulletS.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BulletXNA.dll">

--- a/OpenSim/Region/PhysicsModules/BulletS/Tests/OpenSim.Region.PhysicsModule.BulletS.Tests.csproj
+++ b/OpenSim/Region/PhysicsModules/BulletS/Tests/OpenSim.Region.PhysicsModule.BulletS.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/PhysicsModules/ConvexDecompositionDotNet/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet.csproj
+++ b/OpenSim/Region/PhysicsModules/ConvexDecompositionDotNet/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet.csproj
@@ -5,7 +5,6 @@
     <Company>Intel Corporation</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright © Intel Corporation 2010</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Addins">

--- a/OpenSim/Region/PhysicsModules/Meshing/OpenSim.Region.PhysicsModule.Meshing.csproj
+++ b/OpenSim/Region/PhysicsModules/Meshing/OpenSim.Region.PhysicsModule.Meshing.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Region/PhysicsModules/Ode/Tests/OpenSim.Region.PhysicsModule.Ode.Tests.csproj
+++ b/OpenSim/Region/PhysicsModules/Ode/Tests/OpenSim.Region.PhysicsModule.Ode.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/PhysicsModules/POS/OpenSim.Region.PhysicsModule.POS.csproj
+++ b/OpenSim/Region/PhysicsModules/POS/OpenSim.Region.PhysicsModule.POS.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Addins">

--- a/OpenSim/Region/PhysicsModules/SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
+++ b/OpenSim/Region/PhysicsModules/SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright (c) OpenSimulator.org Developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/PhysicsModules/ubOdeMeshing/OpenSim.Region.PhysicsModule.ubOdeMeshing.csproj
+++ b/OpenSim/Region/PhysicsModules/ubOdeMeshing/OpenSim.Region.PhysicsModule.ubOdeMeshing.csproj
@@ -6,7 +6,6 @@
     <Product>OpenSim</Product>
     <Description>Mesher for ubODE</Description>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Region/ScriptEngine/OpenSim.Region.ScriptEngine.Tests.csproj
+++ b/OpenSim/Region/ScriptEngine/OpenSim.Region.ScriptEngine.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OpenSim.Region.ScriptEngine.Shared.Api.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OpenSim.Region.ScriptEngine.Shared.Api.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OpenSim.Region.ScriptEngine.Shared.Api.Runtime.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OpenSim.Region.ScriptEngine.Shared.Api.Runtime.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/Shared/CodeTools/OpenSim.Region.ScriptEngine.Shared.CodeTools.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/CodeTools/OpenSim.Region.ScriptEngine.Shared.CodeTools.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/Shared/Instance/OpenSim.Region.ScriptEngine.Shared.Instance.csproj
+++ b/OpenSim/Region/ScriptEngine/Shared/Instance/OpenSim.Region.ScriptEngine.Shared.Instance.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/XEngine/Api/Runtime/OpenSim.Region.ScriptEngine.XEngine.Api.Runtime.csproj
+++ b/OpenSim/Region/ScriptEngine/XEngine/Api/Runtime/OpenSim.Region.ScriptEngine.XEngine.Api.Runtime.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/XEngine/OpenSim.Region.ScriptEngine.XEngine.csproj
+++ b/OpenSim/Region/ScriptEngine/XEngine/OpenSim.Region.ScriptEngine.XEngine.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Region/ScriptEngine/YEngine/OpenSim.Region.ScriptEngine.YEngine.csproj
+++ b/OpenSim/Region/ScriptEngine/YEngine/OpenSim.Region.ScriptEngine.YEngine.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Server/Base/OpenSim.Server.Base.csproj
+++ b/OpenSim/Server/Base/OpenSim.Server.Base.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Server/Handlers/OpenSim.Server.Handlers.Tests.csproj
+++ b/OpenSim/Server/Handlers/OpenSim.Server.Handlers.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Server/Handlers/OpenSim.Server.Handlers.csproj
+++ b/OpenSim/Server/Handlers/OpenSim.Server.Handlers.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetOpenId">

--- a/OpenSim/Server/Robust.csproj
+++ b/OpenSim/Server/Robust.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/AssetService/OpenSim.Services.AssetService.csproj
+++ b/OpenSim/Services/AssetService/OpenSim.Services.AssetService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/AuthenticationService/OpenSim.Services.AuthenticationService.csproj
+++ b/OpenSim/Services/AuthenticationService/OpenSim.Services.AuthenticationService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>Copyright ©  2012</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/AuthorizationService/OpenSim.Services.AuthorizationService.csproj
+++ b/OpenSim/Services/AuthorizationService/OpenSim.Services.AuthorizationService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/AvatarService/OpenSim.Services.AvatarService.csproj
+++ b/OpenSim/Services/AvatarService/OpenSim.Services.AvatarService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/Base/OpenSim.Services.Base.csproj
+++ b/OpenSim/Services/Base/OpenSim.Services.Base.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/Connectors/OpenSim.Services.Connectors.csproj
+++ b/OpenSim/Services/Connectors/OpenSim.Services.Connectors.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Services/EstateService/OpenSim.Services.EstateService.csproj
+++ b/OpenSim/Services/EstateService/OpenSim.Services.EstateService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/FSAssetService/OpenSim.Services.FSAssetService.csproj
+++ b/OpenSim/Services/FSAssetService/OpenSim.Services.FSAssetService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/FreeswitchService/OpenSim.Services.FreeswitchService.csproj
+++ b/OpenSim/Services/FreeswitchService/OpenSim.Services.FreeswitchService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/Friends/OpenSim.Services.FriendsService.csproj
+++ b/OpenSim/Services/Friends/OpenSim.Services.FriendsService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/GridService/OpenSim.Services.GridService.csproj
+++ b/OpenSim/Services/GridService/OpenSim.Services.GridService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/HypergridService/OpenSim.Services.HypergridService.csproj
+++ b/OpenSim/Services/HypergridService/OpenSim.Services.HypergridService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/Interfaces/OpenSim.Services.Interfaces.csproj
+++ b/OpenSim/Services/Interfaces/OpenSim.Services.Interfaces.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/InventoryService/OpenSim.Services.InventoryService.csproj
+++ b/OpenSim/Services/InventoryService/OpenSim.Services.InventoryService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/InventoryService/Tests/OpenSim.Services.InventoryService.Tests.csproj
+++ b/OpenSim/Services/InventoryService/Tests/OpenSim.Services.InventoryService.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Services/LLLoginService/OpenSim.Services.LLLoginService.csproj
+++ b/OpenSim/Services/LLLoginService/OpenSim.Services.LLLoginService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/MapImageService/OpenSim.Services.MapImageService.csproj
+++ b/OpenSim/Services/MapImageService/OpenSim.Services.MapImageService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/MuteListService/OpenSim.Services.MuteListService.csproj
+++ b/OpenSim/Services/MuteListService/OpenSim.Services.MuteListService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/PresenceService/OpenSim.Services.PresenceService.csproj
+++ b/OpenSim/Services/PresenceService/OpenSim.Services.PresenceService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/SimulationService/OpenSim.Services.SimulationService.csproj
+++ b/OpenSim/Services/SimulationService/OpenSim.Services.SimulationService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Services/UserAccountService/OpenSim.Services.UserAccountService.csproj
+++ b/OpenSim/Services/UserAccountService/OpenSim.Services.UserAccountService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Services/UserProfilesService/OpenSim.Services.UserProfilesService.csproj
+++ b/OpenSim/Services/UserProfilesService/OpenSim.Services.UserProfilesService.csproj
@@ -5,7 +5,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tests/Clients/Assets/OpenSim.Tests.Clients.AssetClient.csproj
+++ b/OpenSim/Tests/Clients/Assets/OpenSim.Tests.Clients.AssetClient.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tests/Common/OpenSim.Tests.Common.csproj
+++ b/OpenSim/Tests/Common/OpenSim.Tests.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />

--- a/OpenSim/Tests/OpenSim.Tests.csproj
+++ b/OpenSim/Tests/OpenSim.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nini">

--- a/OpenSim/Tests/Performance/OpenSim.Tests.Performance.csproj
+++ b/OpenSim/Tests/Performance/OpenSim.Tests.Performance.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tests/Permissions/OpenSim.Tests.Permissions.csproj
+++ b/OpenSim/Tests/Permissions/OpenSim.Tests.Permissions.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tests/Robust/Robust.Tests.csproj
+++ b/OpenSim/Tests/Robust/Robust.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tests/Stress/OpenSim.Tests.Stress.csproj
+++ b/OpenSim/Tests/Stress/OpenSim.Tests.Stress.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tools/Compiler/OpenSim.Tools.lslc.csproj
+++ b/OpenSim/Tools/Compiler/OpenSim.Tools.lslc.csproj
@@ -6,7 +6,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tools/Configger/OpenSim.Tools.Configger.csproj
+++ b/OpenSim/Tools/Configger/OpenSim.Tools.Configger.csproj
@@ -6,7 +6,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/OpenSim/Tools/pCampBot/pCampBot.csproj
+++ b/OpenSim/Tools/pCampBot/pCampBot.csproj
@@ -6,7 +6,6 @@
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
     <Copyright>OpenSimulator developers</Copyright>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/ThirdParty/SmartThreadPool/SmartThreadPool.csproj
+++ b/ThirdParty/SmartThreadPool/SmartThreadPool.csproj
@@ -6,7 +6,6 @@
     <Description>Smart Thread Pool</Description>
     <AssemblyVersion>2.2.3.0</AssemblyVersion>
     <FileVersion>2.2.3.0</FileVersion>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Web">

--- a/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.csproj
+++ b/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <Target Name="CopyFiles">
     <Copy SourceFiles="@(FilesToCopy_0000)" DestinationFolder="../../../bin/" />

--- a/addon-modules/OpenSimMutelist/Modules/OpenSimMutelist.Modules.csproj
+++ b/addon-modules/OpenSimMutelist/Modules/OpenSimMutelist.Modules.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net48</TargetFramework>
     <AssemblyTitle>OpenSimMuteList.Modules</AssemblyTitle>
     <Product>OpenSim</Product>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">

--- a/addon-modules/OpenSimSearch/Modules/OpenSimSearch.Modules.csproj
+++ b/addon-modules/OpenSimSearch/Modules/OpenSimSearch.Modules.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net48</TargetFramework>
     <AssemblyTitle>OpenSimSearch.Modules</AssemblyTitle>
     <Product>OpenSim</Product>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">


### PR DESCRIPTION
6 Projects still require it but the rest have compilation with the /unsafe option turned off so we aren't inadvertently skipping range and other checks.