### PR TITLE
NUnit: Migrate Startup and Teardown Methods from Obsolete to supported tags.

### DIFF
--- a/OpenSim/Data/Tests/BasicDataServiceTest.cs
+++ b/OpenSim/Data/Tests/BasicDataServiceTest.cs
@@ -89,7 +89,7 @@ namespace OpenSim.Data.Tests
         {
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             // Sorry, some SQLite-specific stuff goes here (not a big deal, as its just some file ops)
@@ -150,7 +150,7 @@ namespace OpenSim.Data.Tests
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void Cleanup()
         {
             if (m_service != null)

--- a/OpenSim/Data/Tests/InventoryTests.cs
+++ b/OpenSim/Data/Tests/InventoryTests.cs
@@ -147,7 +147,7 @@ namespace OpenSim.Data.Tests
             db.addInventoryFolder(f1);
             InventoryFolderBase f1a = db.getUserRootFolder(owner1);
             Assert.That(folder1, Is.EqualTo(f1a.ID), "Assert.That(folder1, Is.EqualTo(f1a.ID))");
-            Assert.That(name1, Is.StringMatching(f1a.Name), "Assert.That(name1, Text.Matches(f1a.Name))");
+            Assert.That(name1, Does.Match(f1a.Name), "Assert.That(name1, Text.Matches(f1a.Name))");
         }
 
         // we now have the following tree

--- a/OpenSim/Region/ClientStack/Linden/UDP/Tests/BasicCircuitTests.cs
+++ b/OpenSim/Region/ClientStack/Linden/UDP/Tests/BasicCircuitTests.cs
@@ -47,14 +47,14 @@ namespace OpenSim.Region.ClientStack.LindenUDP.Tests
     {
         private Scene m_scene;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/ClientStack/Linden/UDP/Tests/LLImageManagerTests.cs
+++ b/OpenSim/Region/ClientStack/Linden/UDP/Tests/LLImageManagerTests.cs
@@ -50,7 +50,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP.Tests
         private LLImageManager llim;
         private TestClient tc;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
@@ -75,7 +75,7 @@ namespace OpenSim.Region.ClientStack.LindenUDP.Tests
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/CoreModules/Avatar/Chat/Tests/ChatModuleTests.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Chat/Tests/ChatModuleTests.cs
@@ -48,7 +48,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat.Tests
     [TestFixture]
     public class ChatModuleTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
@@ -56,7 +56,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Chat.Tests
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/CoreModules/Avatar/Friends/Tests/FriendModuleTests.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Friends/Tests/FriendModuleTests.cs
@@ -44,14 +44,14 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends.Tests
         private FriendsModule m_fm;
         private TestScene m_scene;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/CoreModules/Avatar/Inventory/Archiver/Tests/InventoryArchiveTestCase.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Inventory/Archiver/Tests/InventoryArchiveTestCase.cs
@@ -81,7 +81,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Inventory.Archiver.Tests
         protected string m_item1Name = "Ray Gun Item";
         protected string m_coaItemName = "Coalesced Item";
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureSetup()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
@@ -90,7 +90,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Inventory.Archiver.Tests
             ConstructDefaultIarBytesForTestLoad();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/CoreModules/World/Serialiser/Tests/SerialiserTests.cs
+++ b/OpenSim/Region/CoreModules/World/Serialiser/Tests/SerialiserTests.cs
@@ -592,7 +592,7 @@ namespace OpenSim.Region.CoreModules.World.Serialiser.Tests
         protected Scene m_scene;
         protected SerialiserModule m_serialiserModule;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             m_serialiserModule = new SerialiserModule();

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCrossingTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCrossingTests.cs
@@ -43,14 +43,14 @@ namespace OpenSim.Region.Framework.Scenes.Tests
 {
     public class SceneObjectCrossingTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectDeRezTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectDeRezTests.cs
@@ -52,7 +52,7 @@ namespace OpenSim.Region.Framework.Scenes.Tests
     [TestFixture]
     public class SceneObjectDeRezTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
@@ -61,7 +61,7 @@ namespace OpenSim.Region.Framework.Scenes.Tests
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAutopilotTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAutopilotTests.cs
@@ -44,14 +44,14 @@ namespace OpenSim.Region.Framework.Scenes.Tests
     {
         private TestScene m_scene;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.None;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCrossingTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCrossingTests.cs
@@ -47,14 +47,14 @@ namespace OpenSim.Region.Framework.Scenes.Tests
     [TestFixture]
     public class ScenePresenceCrossingTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceTeleportTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceTeleportTests.cs
@@ -51,14 +51,14 @@ namespace OpenSim.Region.Framework.Scenes.Tests
     [TestFixture]
     public class ScenePresenceTeleportTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/PhysicsModules/BulletS/Tests/BasicVehicles.cs
+++ b/OpenSim/Region/PhysicsModules/BulletS/Tests/BasicVehicles.cs
@@ -53,7 +53,7 @@ public class BasicVehicles : OpenSimTestCase
     Vector3 TestVehicleInitPosition { get; set; }
     float simulationTimeStep = 0.089f;
 
-    [TestFixtureSetUp]
+    [OneTimeSetUp]
     public void Init()
     {
         Dictionary<string, string> engineParams = new Dictionary<string, string>();
@@ -78,7 +78,7 @@ public class BasicVehicles : OpenSimTestCase
 
     }
 
-    [TestFixtureTearDown]
+    [OneTimeTearDown]
     public void TearDown()
     {
         if (PhysicsScene != null)

--- a/OpenSim/Region/PhysicsModules/BulletS/Tests/BulletSimTests.cs
+++ b/OpenSim/Region/PhysicsModules/BulletS/Tests/BulletSimTests.cs
@@ -43,12 +43,12 @@ public class BulletSimTests : OpenSimTestCase
     // Documentation on attributes: http://www.nunit.org/index.php?p=attributes&r=2.6.1
     // Documentation on assertions: http://www.nunit.org/index.php?p=assertions&r=2.6.1
 
-    [TestFixtureSetUp]
+    [OneTimeSetUp]
     public void Init()
     {
     }
 
-    [TestFixtureTearDown]
+    [OneTimeTearDown]
     public void TearDown()
     {
     }

--- a/OpenSim/Region/PhysicsModules/BulletS/Tests/HullCreation.cs
+++ b/OpenSim/Region/PhysicsModules/BulletS/Tests/HullCreation.cs
@@ -51,13 +51,13 @@ public class HullCreation : OpenSimTestCase
     BSScene PhysicsScene { get; set; }
     Vector3 ObjectInitPosition;
 
-    [TestFixtureSetUp]
+    [OneTimeSetUp]
     public void Init()
     {
 
     }
 
-    [TestFixtureTearDown]
+    [OneTimeTearDown]
     public void TearDown()
     {
         if (PhysicsScene != null)

--- a/OpenSim/Region/PhysicsModules/BulletS/Tests/Raycast.cs
+++ b/OpenSim/Region/PhysicsModules/BulletS/Tests/Raycast.cs
@@ -55,7 +55,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS.Tests
 
         uint _targetLocalID = 123;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             Dictionary<string, string> engineParams = new Dictionary<string, string>();
@@ -77,7 +77,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS.Tests
 
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             if (_physicsScene != null)

--- a/OpenSim/Region/PhysicsModules/SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
+++ b/OpenSim/Region/PhysicsModules/SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
@@ -15,10 +15,6 @@
       <HintPath>..\..\..\..\bin\Nini.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\bin\nunit.framework.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="OpenMetaverseTypes">
       <HintPath>..\..\..\..\bin\OpenMetaverseTypes.dll</HintPath>
       <Private>False</Private>

--- a/OpenSim/Region/ScriptEngine/Shared/CodeTools/Tests/CompilerTest.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/CodeTools/Tests/CompilerTest.cs
@@ -55,7 +55,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.CodeTools.Tests
         /// <summary>
         /// Creates a temporary directory where build artifacts are stored.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             m_testDir = Path.Combine(Path.GetTempPath(), "opensim_compilerTest_" + Path.GetRandomFileName());

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiHttpTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiHttpTests.cs
@@ -61,14 +61,14 @@ namespace OpenSim.Region.ScriptEngine.Shared.Tests
         private TaskInventoryItem m_scriptItem;
         private LSL_Api m_lslApi;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixureTearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiNotecardTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiNotecardTests.cs
@@ -34,14 +34,14 @@ namespace OpenSim.Region.ScriptEngine.Shared.Tests
         private TaskInventoryItem m_scriptItem;
         private LSL_Api m_lslApi;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixureTearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLFloat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLFloat.cs
@@ -50,7 +50,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Tests
         /// <summary>
         /// Sets up dictionaries and arrays used in the tests.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUpDataSets()
         {
             m_intDoubleSet = new Dictionary<int, double>();

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLInteger.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLInteger.cs
@@ -41,7 +41,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Tests
         /// <summary>
         /// Sets up dictionaries and arrays used in the tests.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUpDataSets()
         {
             m_doubleIntSet = new Dictionary<double, int>();

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLString.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLString.cs
@@ -40,7 +40,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Tests
         /// <summary>
         /// Sets up dictionaries and arrays used in the tests.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUpDataSets()
         {
             m_doubleStringSet = new Dictionary<double, string>();

--- a/OpenSim/Region/ScriptEngine/XEngine/Tests/XEngineBasicTests.cs
+++ b/OpenSim/Region/ScriptEngine/XEngine/Tests/XEngineBasicTests.cs
@@ -50,7 +50,7 @@ namespace OpenSim.Region.ScriptEngine.XEngine.Tests
         private AutoResetEvent m_chatEvent = new AutoResetEvent(false);
         private OSChatMessage m_osChatMessageReceived;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             //AppDomain.CurrentDomain.SetData("APPBASE", Environment.CurrentDirectory + "/bin");

--- a/OpenSim/Region/ScriptEngine/XEngine/Tests/XEngineCrossingTests.cs
+++ b/OpenSim/Region/ScriptEngine/XEngine/Tests/XEngineCrossingTests.cs
@@ -45,14 +45,14 @@ namespace OpenSim.Region.ScriptEngine.XEngine.Tests
     [TestFixture]
     public class XEngineCrossingTests : OpenSimTestCase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.RegressionTest;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             // We must set this back afterwards, otherwise later tests will fail since they're expecting multiple

--- a/OpenSim/Tests/Performance/NPCPerformanceTests.cs
+++ b/OpenSim/Tests/Performance/NPCPerformanceTests.cs
@@ -64,14 +64,14 @@ namespace OpenSim.Tests.Performance
         private UserManagementModule umm;
         private AttachmentsModule am;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureInit()
         {
             // Don't allow tests to be bamboozled by asynchronous events.  Execute everything on the same thread.
             Util.FireAndForgetMethod = FireAndForgetMethod.None;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             scene.Close();


### PR DESCRIPTION
Remove a bunch of warnings around Obsoleted NUnit test methods. Down to 3 failing tests and no warnings.