### PR TITLE
Fix clamp: focus of the image (hardness / softness) – range -20 to +20.

### DIFF
--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
@@ -4021,7 +4021,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
                 obj.Shape.ProjectionEntry = true;
                 obj.Shape.ProjectionTextureUUID = texID;
                 obj.Shape.ProjectionFOV = Util.Clamp((float)fov, 0, 3.0f);
-                obj.Shape.ProjectionFocus = Util.Clamp((float)focus, 0, 20.0f);
+                obj.Shape.ProjectionFocus = Util.Clamp((float)focus, -20.0f, 20.0f);
                 obj.Shape.ProjectionAmbiance = Util.Clamp((float)amb, 0, 1.0f);
 
                 obj.ParentGroup.HasGroupChanged = true;


### PR DESCRIPTION
This fixes a recent break to osSetProjectionParams, restore the clamp min/max to conform to specs: -20,20.