### PR TITLE
Remove references to log4net

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -238,7 +238,6 @@ This software uses components from the following developers:
 * Prototype JavaScript Framework ajax (http://www.prototypejs.org/)
 * C5 GENERIC COLLECTION LIBRARY FOR C#/CLI
 * Nini (http://nini.sourceforge.net/)
-* log4net (http://logging.apache.org/log4net/)
 * GlynnTucker.Cache (http://gtcache.sourceforge.net/)
 * NDesk.Options 0.2.1 (http://www.ndesk.org/Options)
 * Json.NET 3.5 Release 6.  The binary used is actually Newtonsoft.Json.Net20.dll for Mono 2.4 compatability (http://james.newtonking.com/projects/json-net.aspx)

--- a/Source/Gloebit/CONTRIBUTORS.txt
+++ b/Source/Gloebit/CONTRIBUTORS.txt
@@ -12,7 +12,6 @@ software at it's earliest stages.
 
 This software uses components from the following developers:
 * Microsoft .NET C# (https://docs.microsoft.com/en-us/dotnet/csharp/)
-* log4net (http://logging.apache.org/log4net/)
 * Nini (http://nini.sourceforge.net/)
 * XmlRpcCS (http://xmlrpccs.sf.net/)
 * Mono (https://www.mono-project.com/

--- a/Source/OpenSim.Capabilities/LLSDHelpers.cs
+++ b/Source/OpenSim.Capabilities/LLSDHelpers.cs
@@ -25,19 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
 using System.Collections;
-using System.IO;
 using System.Reflection;
 using System.Xml;
+
 using OpenMetaverse;
 
 namespace OpenSim.Framework.Capabilities
 {
     public class LLSDHelpers
     {
-//        private static readonly log4net.ILog m_log
-//            = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+//        private static ILogger? m_logger;
 
         public static string SerialiseLLSDReply(object obj)
         {
@@ -49,7 +47,7 @@ namespace OpenSim.Framework.Capabilities
                 SerializeOSDType(writer, obj);
                 writer.WriteEndElement();
                 writer.Flush();
-            //m_log.DebugFormat("[LLSD Helpers]: Generated serialized LLSD reply {0}", sw.ToString());
+            //m_logger?.LogDebug("[LLSD Helpers]: Generated serialized LLSD reply {0}", sw.ToString());
 
                 return sw.ToString();
             }
@@ -63,7 +61,7 @@ namespace OpenSim.Framework.Capabilities
                 writer.Formatting = Formatting.None;
                 SerializeOSDType(writer, obj);
                 writer.Flush();
-            //m_log.DebugFormat("[LLSD Helpers]: Generated serialized LLSD reply {0}", sw.ToString());
+            //m_logger?.LogDebug("[LLSD Helpers]: Generated serialized LLSD reply {0}", sw.ToString());
 
                 return sw.ToString();
             }

--- a/Source/OpenSim.Framework.Servers.HttpServer/RestObjectPosterResponse.cs
+++ b/Source/OpenSim.Framework.Servers.HttpServer/RestObjectPosterResponse.cs
@@ -25,8 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.IO;
 using System.Net;
 using System.Text;
 using System.Xml;
@@ -41,8 +39,7 @@ namespace OpenSim.Framework.Servers.HttpServer
     /// </summary>
     public class RestObjectPosterResponse<TResponse>
     {
-//        private static readonly log4net.ILog m_log
-//            = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+//        private static ILogger? m_logger;
 
         public ReturnResponse<TResponse> ResponseCallback;
 
@@ -94,7 +91,7 @@ namespace OpenSim.Framework.Servers.HttpServer
 
                 // This is currently a bad debug stanza since it gobbles us the response...
 //                StreamReader reader = new StreamReader(stream);
-//                m_log.DebugFormat("[REST OBJECT POSTER RESPONSE]: Received {0}", reader.ReadToEnd());
+//                m_logger?.LogDebug("[REST OBJECT POSTER RESPONSE]: Received {0}", reader.ReadToEnd());
 
                 deserial = (TResponse) deserializer.Deserialize(stream);
 

--- a/Source/OpenSim.Region.CoreModules/Avatar/InstantMessage/MuteListModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Avatar/InstantMessage/MuteListModule.cs
@@ -30,8 +30,8 @@ using Microsoft.Extensions.Logging;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
 using OpenSim.Server.Base;
+using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 

--- a/Source/OpenSim.Region.CoreModules/Framework/Library/LocalInventoryService.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/Library/LocalInventoryService.cs
@@ -24,27 +24,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
-
 using OpenSim.Services.Interfaces;
+using OpenSim.Server.Base;
 
 using OpenMetaverse;
-using log4net;
 
 namespace OpenSim.Region.CoreModules.Framework.Library
 {
     public class LocalInventoryService : IInventoryService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private InventoryFolderImpl m_Library;
 
         public LocalInventoryService(InventoryFolderImpl lib)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalInventoryService>>();
             m_Library = lib;
         }
 
@@ -83,7 +82,7 @@ namespace OpenSim.Region.CoreModules.Framework.Library
             inv.Folders = folder.RequestListOfFolders();
             inv.Items = folder.RequestListOfItems();
 
-            m_log.DebugFormat("[LIBRARY MODULE]: Got content for folder {0}", folder.Name);
+            m_logger?.LogDebug("[LIBRARY MODULE]: Got content for folder {0}", folder.Name);
             return inv;
         }
 
@@ -117,14 +116,14 @@ namespace OpenSim.Region.CoreModules.Framework.Library
         /// <returns>true if the folder was successfully added</returns>
         public bool AddFolder(InventoryFolderBase folder)
         {
-            //m_log.DebugFormat("[LIBRARY MODULE]: Adding folder {0} ({1}) to {2}", folder.Name, folder.ID, folder.ParentID);
+            //m_logger?.LogDebug("[LIBRARY MODULE]: Adding folder {0} ({1}) to {2}", folder.Name, folder.ID, folder.ParentID);
             InventoryFolderImpl parent = m_Library;
             if (m_Library.ID != folder.ParentID)
                 parent = m_Library.FindFolder(folder.ParentID);
 
             if (parent == null)
             {
-                m_log.DebugFormat("[LIBRARY MODULE]: could not add folder {0} because parent folder {1} not found", folder.Name, folder.ParentID);
+                m_logger?.LogDebug("[LIBRARY MODULE]: could not add folder {0} because parent folder {1} not found", folder.Name, folder.ParentID);
                 return false;
             }
 
@@ -140,14 +139,14 @@ namespace OpenSim.Region.CoreModules.Framework.Library
         /// <returns>true if the item was successfully added</returns>
         public bool AddItem(InventoryItemBase item)
         {
-            //m_log.DebugFormat("[LIBRARY MODULE]: Adding item {0} to {1}", item.Name, item.Folder);
+            //m_logger?.LogDebug("[LIBRARY MODULE]: Adding item {0} to {1}", item.Name, item.Folder);
             InventoryFolderImpl folder = m_Library;
             if (m_Library.ID != item.Folder)
                 folder = m_Library.FindFolder(item.Folder);
 
             if (folder == null)
             {
-                m_log.DebugFormat("[LIBRARY MODULE]: could not add item {0} because folder {1} not found", item.Name, item.Folder);
+                m_logger?.LogDebug("[LIBRARY MODULE]: could not add item {0} because folder {1} not found", item.Name, item.Folder);
                 return false;
             }
 

--- a/Source/OpenSim.Region.CoreModules/Framework/Monitoring/MonitorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/Monitoring/MonitorModule.cs
@@ -27,8 +27,10 @@
 
 using System.Net;
 using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Framework.Servers;
@@ -37,6 +39,9 @@ using OpenSim.Region.CoreModules.Framework.Monitoring.Alerts;
 using OpenSim.Region.CoreModules.Framework.Monitoring.Monitors;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.Framework.Monitoring
 {
@@ -59,7 +64,7 @@ namespace OpenSim.Region.CoreModules.Framework.Monitoring
         private readonly List<IMonitor> m_staticMonitors = new List<IMonitor>();
 
         private readonly List<IAlert> m_alerts = new List<IAlert>();
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public MonitorModule()
         {
@@ -70,6 +75,7 @@ namespace OpenSim.Region.CoreModules.Framework.Monitoring
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MonitorModule>>();
             IConfig cnfg = source.Configs["Monitoring"];
 
             if (cnfg != null)
@@ -389,7 +395,7 @@ namespace OpenSim.Region.CoreModules.Framework.Monitoring
 
         void OnTriggerAlert(System.Type reporter, string reason, bool fatal)
         {
-            m_log.Error("[Monitor] " + reporter.Name + " for " + m_scene.RegionInfo.RegionName + " reports " + reason + " (Fatal: " + fatal + ")");
+            m_logger?.LogError("[Monitor] " + reporter.Name + " for " + m_scene.RegionInfo.RegionName + " reports " + reason + " (Fatal: " + fatal + ")");
         }
 
         private List<Stat> registeredStats = new List<Stat>();

--- a/Source/OpenSim.Region.CoreModules/Framework/Search/BasicSearchModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/Search/BasicSearchModule.cs
@@ -24,15 +24,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
+using OpenSim.Server.Base;
 
 using OpenMetaverse;
-using log4net;
+
 using Nini.Config;
 
 using DirFindFlags = OpenMetaverse.DirectoryManager.DirFindFlags;
@@ -41,7 +44,7 @@ namespace OpenSim.Region.CoreModules.Framework.Search
 {
     public class BasicSearchModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected bool m_Enabled;
         protected List<Scene> m_Scenes = new List<Scene>();
@@ -55,11 +58,12 @@ namespace OpenSim.Region.CoreModules.Framework.Search
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<BasicSearchModule>>();
             string umanmod = config.Configs["Modules"].GetString("SearchModule", Name);
             if (umanmod == Name)
             {
                 m_Enabled = true;
-                m_log.DebugFormat("[BASIC SEARCH MODULE]: {0} is enabled", Name);
+                m_logger?.LogDebug("[BASIC SEARCH MODULE]: {0} is enabled", Name);
             }
         }
 
@@ -111,7 +115,7 @@ namespace OpenSim.Region.CoreModules.Framework.Search
 
                 // No Groups Service Connector, then group search won't work...
                 if (m_GroupsService == null)
-                    m_log.Warn("[BASIC SEARCH MODULE]: Could not get IGroupsModule");
+                    m_logger?.LogWarning("[BASIC SEARCH MODULE]: Could not get IGroupsModule");
             }
         }
 
@@ -200,7 +204,7 @@ namespace OpenSim.Region.CoreModules.Framework.Search
             {
                 if (m_GroupsService == null)
                 {
-                    m_log.Warn("[BASIC SEARCH MODULE]: Groups service is not available. Unable to search groups.");
+                    m_logger?.LogWarning("[BASIC SEARCH MODULE]: Groups service is not available. Unable to search groups.");
                     remoteClient.SendAlertMessage("Groups search is not enabled");
                     return;
                 }

--- a/Source/OpenSim.Region.CoreModules/Framework/ServiceThrottle/ServiceThrottleModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/ServiceThrottle/ServiceThrottleModule.cs
@@ -25,22 +25,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
-using OpenMetaverse;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Scenes;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using OpenSim.Server.Base;
+
+using OpenMetaverse;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.Framework.ServiceThrottle
 {
     public class ServiceThrottleModule : ISharedRegionModule, IServiceThrottleModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private readonly List<Scene> m_scenes = new List<Scene>();
         private JobEngine m_processorJobEngine;
@@ -49,6 +52,7 @@ namespace OpenSim.Region.CoreModules.Framework.ServiceThrottle
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ServiceThrottleModule>>();
             m_processorJobEngine = new JobEngine("ServiceThrottle","ServiceThrottle", 5000, 2);
             m_processorJobEngine.Start();
         }

--- a/Source/OpenSim.Region.CoreModules/Framework/UserManagement/HGUserManagementModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/UserManagement/HGUserManagementModule.cs
@@ -24,32 +24,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Services.Connectors.Hypergrid;
+using OpenSim.Server.Base;
 
 using OpenMetaverse;
-using log4net;
+
 using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.Framework.UserManagement
 {
     public class HGUserManagementModule : UserManagementModule, ISharedRegionModule, IUserManagement
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         #region ISharedRegionModule
 
         public override void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<HGUserManagementModule>>();
             string umanmod = config.Configs["Modules"].GetString("UserManagementModule", null);
             if (umanmod == Name)
             {
                 m_Enabled = true;
                 base.Init(config);
-                m_log.DebugFormat("[USER MANAGEMENT MODULE]: {0} is enabled", Name);
+                m_logger?.LogDebug("[USER MANAGEMENT MODULE]: {0} is enabled", Name);
             }
         }
 
@@ -67,7 +71,7 @@ namespace OpenSim.Region.CoreModules.Framework.UserManagement
                 string[] words = query.Split(new char[] { '@' });
                 if (words.Length != 2)
                 {
-                    m_log.DebugFormat("[USER MANAGEMENT MODULE]: Malformed address {0}", query);
+                    m_logger?.LogDebug("[USER MANAGEMENT MODULE]: Malformed address {0}", query);
                     return;
                 }
 
@@ -118,7 +122,7 @@ namespace OpenSim.Region.CoreModules.Framework.UserManagement
                         }
                         catch (UriFormatException)
                         {
-                            m_log.DebugFormat("[USER MANAGEMENT MODULE]: Malformed address {0}", uriStr);
+                            m_logger?.LogDebug("[USER MANAGEMENT MODULE]: Malformed address {0}", uriStr);
                             return;
                         }
 
@@ -133,7 +137,7 @@ namespace OpenSim.Region.CoreModules.Framework.UserManagement
                             }
                             catch (Exception e)
                             {
-                                m_log.Debug("[USER MANAGEMENT MODULE]: GetUUID call failed ", e);
+                                m_logger?.LogDebug("[USER MANAGEMENT MODULE]: GetUUID call failed ", e);
                             }
                         }
 
@@ -145,10 +149,10 @@ namespace OpenSim.Region.CoreModules.Framework.UserManagement
                             ud.LastName = "@" + words[1];
                             users.Add(ud);
                             AddUser(userID, names[0], names[1], uriStr);
-                            m_log.DebugFormat("[USER MANAGEMENT MODULE]: User {0}@{1} found", words[0], words[1]);
+                            m_logger?.LogDebug("[USER MANAGEMENT MODULE]: User {0}@{1} found", words[0], words[1]);
                         }
                         else
-                            m_log.DebugFormat("[USER MANAGEMENT MODULE]: User {0}@{1} not found", words[0], words[1]);
+                            m_logger?.LogDebug("[USER MANAGEMENT MODULE]: User {0}@{1} not found", words[0], words[1]);
                     }
                 }
             }

--- a/Source/OpenSim.Region.CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/DynamicTexture/DynamicTextureModule.cs
@@ -28,20 +28,25 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
-using Nini.Config;
-using OpenMetaverse;
-using OpenMetaverse.Imaging;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using log4net;
-using System.Reflection;
+using OpenSim.Server.Base;
+
+using OpenMetaverse;
+using OpenMetaverse.Imaging;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
 {
     public class DynamicTextureModule : ISharedRegionModule, IDynamicTextureManager
     {
-//        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private const int ALL_SIDES = -1;
 
@@ -86,6 +91,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
         /// </summary>
         public DynamicTextureModule()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DynamicTextureModule>>();
             m_reuseableDynamicTextures = new Cache(CacheMedium.Memory, CacheStrategy.Conservative);
             m_reuseableDynamicTextures.DefaultTTL = new TimeSpan(24, 0, 0);
         }
@@ -330,6 +336,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DynamicTextureModule>>();
             IConfig texturesConfig = config.Configs["Textures"];
             if (texturesConfig != null)
             {
@@ -387,7 +394,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
 
         public class DynamicTextureUpdater
         {
-            private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+            private static ILogger? m_logger;
 
             public bool BlendWithOldTexture = false;
             public string BodyData;
@@ -404,6 +411,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
 
             public DynamicTextureUpdater()
             {
+                m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DynamicTextureUpdater>>();
                 BodyData = null;
             }
 
@@ -571,7 +579,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
                     }
                     catch (Exception e)
                     {
-                        m_log.ErrorFormat(
+                        m_logger?.LogError(
                         "[DYNAMICTEXTUREMODULE]: OpenJpeg Encode Failed.  Exception {0}{1}",
                             e.Message, e.StackTrace);
                     }
@@ -601,7 +609,7 @@ namespace OpenSim.Region.CoreModules.Scripting.DynamicTexture
                     }
                     catch (Exception e)
                     {
-                        m_log.ErrorFormat(
+                        m_logger?.LogError(
                         "[DYNAMICTEXTUREMODULE]: OpenJpeg Encode Failed.  Exception {0}{1}",
                             e.Message, e.StackTrace);
                     }

--- a/Source/OpenSim.Region.CoreModules/Scripting/LoadImageURL/LoadImageURLModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/LoadImageURL/LoadImageURLModule.cs
@@ -27,20 +27,25 @@
 
 using System.Drawing;
 using System.Net;
-using Nini.Config;
-using OpenMetaverse;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse.Imaging;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using log4net;
-using System.Reflection;
+using OpenSim.Server.Base;
+
+using OpenMetaverse;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
 {
     public class LoadImageURLModule : ISharedRegionModule, IDynamicTextureRender
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private string m_name = "LoadImageURL";
         private Scene m_scene;
@@ -105,6 +110,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LoadImageURLModule>>();
             m_outboundUrlFilter = new OutboundUrlFilter("Script dynamic texture image module", config);
             string proxyurl = config.Configs["Startup"].GetString("HttpProxy");
             if(!string.IsNullOrEmpty(proxyurl))
@@ -164,7 +170,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
         {
             if (m_textureManager is null)
             {
-                m_log.WarnFormat("[LOADIMAGEURLMODULE]: No texture manager. Can't function.");
+                m_logger?.LogWarning("[LOADIMAGEURLMODULE]: No texture manager. Can't function.");
                 return false;
             }
 
@@ -250,12 +256,12 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
                         }
                         catch (Exception)
                         {
-                            m_log.Error("[LOADIMAGEURLMODULE]: OpenJpeg Conversion Failed.  Empty byte data returned!");
+                            m_logger?.LogError("[LOADIMAGEURLMODULE]: OpenJpeg Conversion Failed.  Empty byte data returned!");
                         }
                     }
                     else
                     {
-                        m_log.WarnFormat("[LOADIMAGEURLMODULE] No data returned");
+                        m_logger?.LogWarning("[LOADIMAGEURLMODULE] No data returned");
                     }
                 }
             }
@@ -264,7 +270,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
             }
             catch (Exception e)
             {
-                m_log.ErrorFormat("[LOADIMAGEURLMODULE]: unexpected exception {0}", e.Message);
+                m_logger?.LogError("[LOADIMAGEURLMODULE]: unexpected exception {0}", e.Message);
             }
             finally
             {
@@ -284,7 +290,7 @@ namespace OpenSim.Region.CoreModules.Scripting.LoadImageURL
                     }
                     else
                     {
-                        m_log.DebugFormat("[LOADIMAGEURLMODULE]: Returning {0} bytes of image data for request {1}",
+                        m_logger?.LogDebug("[LOADIMAGEURLMODULE]: Returning {0} bytes of image data for request {1}",
                                           imageJ2000.Length, state.RequestID);
 
                         m_textureManager.ReturnData(

--- a/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
@@ -29,13 +29,18 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.Net;
-using Nini.Config;
-using OpenMetaverse;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse.Imaging;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using log4net;
-using System.Reflection;
+using OpenSim.Server.Base;
+
+using OpenMetaverse;
+
+using Nini.Config;
 
 //using Cairo;
 
@@ -48,7 +53,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
 //        private static byte[] s_asset1Data;
 //        private static byte[] s_asset2Data;
 
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static object thisLock = new object();
         private static Graphics m_graph = null; // just to get chars sizes
 
@@ -59,6 +64,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
 
         public VectorRenderModule()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<VectorRenderModule>>();
         }
 
         #region IDynamicTextureRender Members
@@ -134,12 +140,13 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<VectorRenderModule>>();
             IConfig cfg = config.Configs["VectorRender"];
             if (null != cfg)
             {
                 m_fontName = cfg.GetString("font_name", m_fontName);
             }
-            m_log.DebugFormat("[VECTORRENDERMODULE]: using font \"{0}\" for text rendering.", m_fontName);
+            m_logger?.LogDebug("[VECTORRENDERMODULE]: using font \"{0}\" for text rendering.", m_fontName);
 
             // We won't dispose of these explicitly since this module is only removed when the entire simulator
             // is shut down.
@@ -392,7 +399,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
                 }
                 catch (Exception e)
                 {
-                    m_log.ErrorFormat(
+                    m_logger?.LogError(
                         "[VECTORRENDERMODULE]: OpenJpeg Encode Failed.  Exception {0}{1}",
                         e.Message, e.StackTrace);
                 }
@@ -503,7 +510,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
                 {
                     string nextLine = line.TrimStart();
 
-//                    m_log.DebugFormat("[VECTOR RENDER MODULE]: Processing line '{0}'", nextLine);
+//                    m_logger?.LogDebug("[VECTOR RENDER MODULE]: Processing line '{0}'", nextLine);
 
                     if (nextLine.StartsWith("Text") && nextLine.Length > 5)
                     {
@@ -853,7 +860,7 @@ namespace OpenSim.Region.CoreModules.Scripting.VectorRender
                     PointF point = new PointF(x, y);
                     points[i / 2] = point;
 
-//                    m_log.DebugFormat("[VECTOR RENDER MODULE]: Got point {0}", points[i / 2]);
+//                    m_logger?.LogDebug("[VECTOR RENDER MODULE]: Got point {0}", points[i / 2]);
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/Scripting/WorldComm/WorldCommModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/WorldComm/WorldCommModule.cs
@@ -28,16 +28,17 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
-using Nini.Config;
-
-using OpenMetaverse;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 
-// using log4net;
-// using System.Reflection;
+using OpenMetaverse;
+
+using Nini.Config;
 
 
 /*****************************************************
@@ -89,7 +90,7 @@ namespace OpenSim.Region.CoreModules.Scripting.WorldComm
 {
     public class WorldCommModule : IWorldComm, INonSharedRegionModule
     {
-        // private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private const int DEBUG_CHANNEL = 0x7fffffff;
 
@@ -108,6 +109,7 @@ namespace OpenSim.Region.CoreModules.Scripting.WorldComm
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<WorldCommModule>>();
             // wrap this in a try block so that defaults will work if
             // the config file doesn't specify otherwise.
             try
@@ -372,7 +374,7 @@ namespace OpenSim.Region.CoreModules.Scripting.WorldComm
         public void DeliverMessage(ChatTypeEnum type, int channel,
                 string name, UUID id, string msg, Vector3 position)
         {
-            // m_log.DebugFormat("[WorldComm] got[2] type {0}, channel {1}, name {2}, id {3}, msg {4}",
+            // m_logger?.LogDebug("[WorldComm] got[2] type {0}, channel {1}, name {2}, id {3}, msg {4}",
             //                   type, channel, name, id, msg);
 
             // validate type and set range

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Asset/AssetServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Asset/AssetServiceInConnectorModule.cs
@@ -25,20 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Asset
 {
     public class AssetServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -48,6 +50,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Asset
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<AssetServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -55,7 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Asset
                 m_Enabled = moduleConfig.GetBoolean("AssetServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[ASSET IN CONNECTOR]: AssetServiceInConnector enabled");
+                    m_logger?.LogInformation("[ASSET IN CONNECTOR]: AssetServiceInConnector enabled");
                 }
 
             }
@@ -88,7 +91,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Asset
             {
                 m_Registered = true;
 
-                m_log.Info("[HGAssetService]: Starting...");
+                m_logger?.LogInformation("[HGAssetService]: Starting...");
 
 
                 object[] args = new object[] { m_Config, MainServer.Instance, "HGAssetService" };

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Authentication/AuthenticationServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Authentication/AuthenticationServiceInConnectorModule.cs
@@ -25,19 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Handlers.Authentication;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Authentication
 {
     public class AuthenticationServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -47,6 +50,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Authentication
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<AuthenticationServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -54,7 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Authentication
                 m_Enabled = moduleConfig.GetBoolean("AuthenticationServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[AUTHENTICATION IN CONNECTOR]: Authentication Service In Connector enabled");
+                    m_logger?.LogInformation("[AUTHENTICATION IN CONNECTOR]: Authentication Service In Connector enabled");
                 }
 
             }
@@ -100,7 +104,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Authentication
             {
                 m_Registered = true;
 
-                m_log.Info("[AUTHENTICATION IN CONNECTOR]: Starting...");
+                m_logger?.LogInformation("[AUTHENTICATION IN CONNECTOR]: Starting...");
 
                 new AuthenticationServiceConnector(m_Config, MainServer.Instance, "AuthenticationService");
             }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Grid/GridInfoServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Grid/GridInfoServiceInConnectorModule.cs
@@ -25,19 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Handlers.Grid;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Grid
 {
     public class GridInfoServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -47,6 +50,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Grid
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<GridInfoServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -54,7 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Grid
                 m_Enabled = moduleConfig.GetBoolean("GridInfoServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[GRIDINFO IN CONNECTOR]: GridInfo Service In Connector enabled");
+                    m_logger?.LogInformation("[GRIDINFO IN CONNECTOR]: GridInfo Service In Connector enabled");
                 }
 
             }
@@ -100,7 +104,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Grid
             {
                 m_Registered = true;
 
-                m_log.Info("[GridInfo]: Starting...");
+                m_logger?.LogInformation("[GridInfo]: Starting...");
 
                 new GridInfoServerInConnector(m_Config, MainServer.Instance, "GridInfoService");
             }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Hypergrid/HypergridServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Hypergrid/HypergridServiceInConnectorModule.cs
@@ -26,8 +26,10 @@
  */
 
 using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
@@ -35,11 +37,13 @@ using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Hypergrid;
 using OpenSim.Services.Interfaces;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Hypergrid
 {
     public class HypergridServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -52,6 +56,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Hypergrid
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<HypergridServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -59,7 +64,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Hypergrid
                 m_Enabled = moduleConfig.GetBoolean("HypergridServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[HGGRID IN CONNECTOR]: Hypergrid Service In Connector enabled");
+                    m_logger?.LogInformation("[HGGRID IN CONNECTOR]: Hypergrid Service In Connector enabled");
                     IConfig fconfig = config.Configs["FriendsService"];
                     if (fconfig != null)
                     {
@@ -110,7 +115,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Hypergrid
             {
                 m_Registered = true;
 
-                m_log.Info("[HypergridService]: Starting...");
+                m_logger?.LogInformation("[HypergridService]: Starting...");
 
                 ISimulationService simService = scene.RequestModuleInterface<ISimulationService>();
                 IFriendsSimConnector friendsConn = scene.RequestModuleInterface<IFriendsSimConnector>();

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Inventory/InventoryServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Inventory/InventoryServiceInConnectorModule.cs
@@ -26,19 +26,23 @@
  */
 
 using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Inventory
 {
     public class InventoryServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -48,6 +52,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Inventory
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<InventoryServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -55,7 +60,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Inventory
                 m_Enabled = moduleConfig.GetBoolean("InventoryServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[INVENTORY IN CONNECTOR]: Inventory Service In Connector enabled");
+                    m_logger?.LogInformation("[INVENTORY IN CONNECTOR]: Inventory Service In Connector enabled");
                 }
             }
         }
@@ -87,7 +92,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Inventory
             {
                 m_Registered = true;
 
-                m_log.Info("[RegionInventoryService]: Starting...");
+                m_logger?.LogInformation("[RegionInventoryService]: Starting...");
 
                 Object[] args = new Object[] { m_Config, MainServer.Instance, "HGInventoryService" };
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Land/LandServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Land/LandServiceInConnectorModule.cs
@@ -26,8 +26,10 @@
  */
 
 using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
@@ -35,14 +37,17 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 using OpenSim.Services.Interfaces;
+
 using OpenMetaverse;
+
+using Nini.Config;
 
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
 {
     public class LandServiceInConnectorModule : ISharedRegionModule, ILandService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
         private static bool m_Registered = false;
 
@@ -53,6 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LandServiceInConnectorModule>>();
             m_Config = config;
 
             IConfig moduleConfig = config.Configs["Modules"];
@@ -61,7 +67,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
                 m_Enabled = moduleConfig.GetBoolean("LandServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[LAND IN CONNECTOR]: LandServiceInConnector enabled");
+                    m_logger?.LogInformation("[LAND IN CONNECTOR]: LandServiceInConnector enabled");
                 }
 
             }
@@ -73,7 +79,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
             if (!m_Enabled)
                 return;
 
-//            m_log.Info("[LAND IN CONNECTOR]: Starting...");
+//            m_logger?.LogInformation("[LAND IN CONNECTOR]: Starting...");
         }
 
         public void Close()
@@ -122,7 +128,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
 
         public LandData GetLandData(UUID scopeID, ulong regionHandle, uint x, uint y, out byte regionAccess)
         {
-//            m_log.DebugFormat("[LAND IN CONNECTOR]: GetLandData for {0}. Count = {1}",
+//            m_logger?.LogDebug("[LAND IN CONNECTOR]: GetLandData for {0}. Count = {1}",
 //                regionHandle, m_Scenes.Count);
 
             uint rx = 0, ry = 0;
@@ -154,7 +160,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Land
                     return land; 
                 }
             }
-            m_log.DebugFormat("[LAND IN CONNECTOR]: region handle {0} not found", regionHandle);
+            m_logger?.LogDebug("[LAND IN CONNECTOR]: region handle {0} not found", regionHandle);
             regionAccess = 42;
             return null;
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Login/LLLoginServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Login/LLLoginServiceInConnectorModule.cs
@@ -25,20 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Handlers.Login;
+using OpenSim.Server.Base;
 
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Login
 {
     public class LLLoginServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
         private static bool m_Registered = false;
 
@@ -49,6 +51,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Login
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LLLoginServiceInConnectorModule>>();
             m_Config = config;
 
             IConfig moduleConfig = config.Configs["Modules"];
@@ -57,7 +60,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Login
                 m_Enabled = moduleConfig.GetBoolean("LLLoginServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[LLLOGIN IN CONNECTOR]: LLLoginerviceInConnector enabled");
+                    m_logger?.LogInformation("[LLLOGIN IN CONNECTOR]: LLLoginerviceInConnector enabled");
                 }
 
             }
@@ -69,7 +72,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Login
             if (!m_Enabled)
                 return;
 
-            m_log.Info("[LLLOGIN IN CONNECTOR]: Starting...");
+            m_logger?.LogInformation("[LLLOGIN IN CONNECTOR]: Starting...");
         }
 
         public void Close()

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/MapImage/MapImageServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/MapImage/MapImageServiceInConnectorModule.cs
@@ -25,19 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Handlers.MapImage;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.MapImage
 {
     public class MapImageServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -46,6 +49,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.MapImage
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MapImageServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -53,7 +57,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.MapImage
                 m_Enabled = moduleConfig.GetBoolean("MapImageServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[MAP SERVICE IN CONNECTOR]: MapImage Service In Connector enabled");
+                    m_logger?.LogInformation("[MAP SERVICE IN CONNECTOR]: MapImage Service In Connector enabled");
                     new MapGetServiceConnector(m_Config, MainServer.Instance, "MapImageService");
                 }
             }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Neighbour/NeighbourServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Neighbour/NeighbourServiceInConnectorModule.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
@@ -36,12 +36,14 @@ using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 using OpenSim.Services.Interfaces;
 
+using Nini.Config;
+
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Neighbour
 {
     public class NeighbourServiceInConnectorModule : ISharedRegionModule, INeighbourService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
         private static bool m_Registered = false;
 
@@ -52,6 +54,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Neighbour
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<NeighbourServiceInConnectorModule>>();
             m_Config = config;
 
             IConfig moduleConfig = config.Configs["Modules"];
@@ -60,7 +63,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Neighbour
                 m_Enabled = moduleConfig.GetBoolean("NeighbourServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[NEIGHBOUR IN CONNECTOR]: NeighbourServiceInConnector enabled");
+                    m_logger?.LogInformation("[NEIGHBOUR IN CONNECTOR]: NeighbourServiceInConnector enabled");
                 }
 
             }
@@ -72,7 +75,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Neighbour
             if (!m_Enabled)
                 return;
 
-//            m_log.Info("[NEIGHBOUR IN CONNECTOR]: Starting...");
+//            m_logger?.LogInformation("[NEIGHBOUR IN CONNECTOR]: Starting...");
         }
 
         public void Close()

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Simulation/SimulationServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Simulation/SimulationServiceInConnectorModule.cs
@@ -25,21 +25,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Simulation
 {
     public class SimulationServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -49,6 +47,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Simulation
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<SimulationServiceInConnectorModule>>();
             m_Config = config;
 
             IConfig moduleConfig = config.Configs["Modules"];
@@ -57,7 +56,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Simulation
                 m_Enabled = moduleConfig.GetBoolean("SimulationServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[SIM SERVICE]: SimulationService IN connector enabled");
+                    m_logger?.LogInformation("[SIM SERVICE]: SimulationService IN connector enabled");
 
                 }
             }
@@ -102,7 +101,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Simulation
             {
                 m_Registered = true;
 
-                m_log.Info("[SIM SERVICE]: Starting...");
+                m_logger?.LogInformation("[SIM SERVICE]: Starting...");
 
                 Object[] args = new Object[] { m_Config, MainServer.Instance, scene };
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/UserProfiles/LocalUserProfilesServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/UserProfiles/LocalUserProfilesServiceConnector.cs
@@ -26,9 +26,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using Nini.Config;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers;
 using OpenSim.Region.Framework.Interfaces;
@@ -36,13 +36,17 @@ using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
+using OpenSim.Server.Base;
+
 using OpenMetaverse;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
 {
     public class LocalUserProfilesServicesConnector : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private Dictionary<UUID, Scene> regions = new Dictionary<UUID, Scene>();
 
@@ -76,12 +80,12 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
 
         public LocalUserProfilesServicesConnector()
         {
-            //m_log.Debug("[LOCAL USERPROFILES SERVICE CONNECTOR]: LocalUserProfileServicesConnector no params");
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalUserProfilesServicesConnector>>();
         }
 
-        public LocalUserProfilesServicesConnector(IConfiguration source)
+        public LocalUserProfilesServicesConnector(IConfiguration source) : this()
         {
-            //m_log.Debug("[LOCAL USERPROFILES SERVICE CONNECTOR]: LocalUserProfileServicesConnector instantiated directly.");
+            //m_logger?.LogDebug("[LOCAL USERPROFILES SERVICE CONNECTOR]: LocalUserProfileServicesConnector instantiated directly.");
             InitialiseService(source);
         }
 
@@ -95,7 +99,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
             IConfig config = source.Configs[ConfigName];
             if (config == null)
             {
-                //m_log.Error("[LOCAL USERPROFILES SERVICE CONNECTOR]: UserProfilesService missing from OpenSim.ini");
+                //m_logger?.LogError("[LOCAL USERPROFILES SERVICE CONNECTOR]: UserProfilesService missing from OpenSim.ini");
                 return;
             }
 
@@ -111,7 +115,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
 
             if (serviceDll.Length == 0)
             {
-                m_log.Error("[LOCAL USERPROFILES SERVICE CONNECTOR]: No LocalServiceModule named in section UserProfilesService");
+                m_logger?.LogError("[LOCAL USERPROFILES SERVICE CONNECTOR]: No LocalServiceModule named in section UserProfilesService");
                 return;
             }
 
@@ -120,7 +124,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
 
             if (ServiceModule == null)
             {
-                m_log.Error("[LOCAL USERPROFILES SERVICE CONNECTOR]: Can't load user profiles service");
+                m_logger?.LogError("[LOCAL USERPROFILES SERVICE CONNECTOR]: Can't load user profiles service");
                 return;
             }
 
@@ -163,6 +167,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalUserProfilesServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -170,7 +175,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Profile
                 if (name == Name)
                 {
                     InitialiseService(source);
-                    m_log.Info("[LOCAL USERPROFILES SERVICE CONNECTOR]: Local user profiles connector enabled");
+                    m_logger?.LogInformation("[LOCAL USERPROFILES SERVICE CONNECTOR]: Local user profiles connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/AgentPreferences/LocalAgentPreferencesServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/AgentPreferences/LocalAgentPreferencesServiceConnector.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
@@ -35,11 +35,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 {
     public class LocalAgentPreferencesServicesConnector : ISharedRegionModule, IAgentPreferencesService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IAgentPreferencesService m_AgentPreferencesService;
         private bool m_Enabled = false;
@@ -58,6 +60,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalAgentPreferencesServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -67,7 +70,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
                     IConfig userConfig = source.Configs["AgentPreferencesService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[AGENT PREFERENCES CONNECTOR]: AgentPreferencesService missing from OpenSim.ini");
+                        m_logger?.LogError("[AGENT PREFERENCES CONNECTOR]: AgentPreferencesService missing from OpenSim.ini");
                         return;
                     }
 
@@ -75,7 +78,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 
                     if (String.IsNullOrEmpty(serviceDll))
                     {
-                        m_log.Error("[AGENT PREFERENCES CONNECTOR]: No AgentPreferencesModule named in section AgentPreferencesService");
+                        m_logger?.LogError("[AGENT PREFERENCES CONNECTOR]: No AgentPreferencesModule named in section AgentPreferencesService");
                         return;
                     }
 
@@ -84,11 +87,11 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 
                     if (m_AgentPreferencesService == null)
                     {
-                        m_log.Error("[AGENT PREFERENCES CONNECTOR]: Can't load agent preferences service");
+                        m_logger?.LogError("[AGENT PREFERENCES CONNECTOR]: Can't load agent preferences service");
                         return;
                     }
                     m_Enabled = true;
-                    m_log.Info("[AGENT PREFERENCES CONNECTOR]: Local agent preferences connector enabled");
+                    m_logger?.LogInformation("[AGENT PREFERENCES CONNECTOR]: Local agent preferences connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/AgentPreferences/RemoteAgentPreferencesServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/AgentPreferences/RemoteAgentPreferencesServiceConnector.cs
@@ -25,14 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
-using log4net;
+using OpenSim.Server.Base;
+
 using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
@@ -40,7 +41,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
     public class RemoteAgentPreferencesServicesConnector : AgentPreferencesServicesConnector,
             ISharedRegionModule, IAgentPreferencesService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
 
@@ -56,6 +57,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 
         public new void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteAgentPreferencesServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -65,7 +67,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
                     IConfig userConfig = source.Configs["AgentPreferencesService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[AGENT PREFERENCES CONNECTOR]: AgentPreferencesService missing from OpenSim.ini");
+                        m_logger?.LogError("[AGENT PREFERENCES CONNECTOR]: AgentPreferencesService missing from OpenSim.ini");
                         return;
                     }
 
@@ -73,7 +75,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.AgentPreferences
 
                     base.Initialise(source);
 
-                    m_log.Info("[AGENT PREFERENCES CONNECTOR]: Remote agent preferences enabled");
+                    m_logger?.LogInformation("[AGENT PREFERENCES CONNECTOR]: Remote agent preferences enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authentication/LocalAuthenticationServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authentication/LocalAuthenticationServiceConnector.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
@@ -35,13 +35,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 {
     public class LocalAuthenticationServicesConnector : ISharedRegionModule, IAuthenticationService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IAuthenticationService m_AuthenticationService;
 
@@ -61,6 +61,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalAuthenticationServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -70,7 +71,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
                     IConfig userConfig = source.Configs["AuthenticationService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[AUTH CONNECTOR]: AuthenticationService missing from OpenSim.ini");
+                        m_logger?.LogError("[AUTH CONNECTOR]: AuthenticationService missing from OpenSim.ini");
                         return;
                     }
 
@@ -79,7 +80,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 
                     if (serviceDll.Length == 0)
                     {
-                        m_log.Error("[AUTH CONNECTOR]: No LocalServiceModule named in section AuthenticationService");
+                        m_logger?.LogError("[AUTH CONNECTOR]: No LocalServiceModule named in section AuthenticationService");
                         return;
                     }
 
@@ -90,11 +91,11 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 
                     if (m_AuthenticationService == null)
                     {
-                        m_log.Error("[AUTH CONNECTOR]: Can't load Authentication service");
+                        m_logger?.LogError("[AUTH CONNECTOR]: Can't load Authentication service");
                         return;
                     }
                     m_Enabled = true;
-                    m_log.Info("[AUTH CONNECTOR]: Local Authentication connector enabled");
+                    m_logger?.LogInformation("[AUTH CONNECTOR]: Local Authentication connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authentication/RemoteAuthenticationServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authentication/RemoteAuthenticationServiceConnector.cs
@@ -25,22 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using Nini.Config;
-using log4net;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 {
     public class RemoteAuthenticationServicesConnector : AuthenticationServicesConnector,
             ISharedRegionModule, IAuthenticationService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
 
@@ -56,6 +57,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 
         public override void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteAuthenticationServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -65,7 +67,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
                     IConfig userConfig = source.Configs["AuthenticationService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[AUTH CONNECTOR]: AuthenticationService missing from OpenSim.ini");
+                        m_logger?.LogError("[AUTH CONNECTOR]: AuthenticationService missing from OpenSim.ini");
                         return;
                     }
 
@@ -73,7 +75,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authentication
 
                     base.Initialise(source);
 
-                    m_log.Info("[AUTH CONNECTOR]: Remote Authentication enabled");
+                    m_logger?.LogInformation("[AUTH CONNECTOR]: Remote Authentication enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authorization/LocalAuthorizationServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Authorization/LocalAuthorizationServiceConnector.cs
@@ -25,18 +25,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using Nini.Config;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authorization
 {
     public class LocalAuthorizationServicesConnector : INonSharedRegionModule, IAuthorizationService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IAuthorizationService m_AuthorizationService;
         private Scene m_Scene;
@@ -56,7 +59,8 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authorization
 
         public void Initialise(IConfiguration source)
         {
-            m_log.Info("[AUTHORIZATION CONNECTOR]: Initialise");
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalAuthorizationServicesConnector>>();
+            m_logger?.LogInformation("[AUTHORIZATION CONNECTOR]: Initialise");
 
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
@@ -66,7 +70,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authorization
                 {
                     m_Enabled = true;
                     m_AuthorizationConfig = source.Configs["AuthorizationService"];
-                    m_log.Info("[AUTHORIZATION CONNECTOR]: Local authorization connector enabled");
+                    m_logger?.LogInformation("[AUTHORIZATION CONNECTOR]: Local authorization connector enabled");
                 }
             }
         }
@@ -99,7 +103,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Authorization
 
             m_AuthorizationService = new AuthorizationService(m_AuthorizationConfig, scene);
 
-            m_log.InfoFormat(
+            m_logger?.LogInformation(
                 "[AUTHORIZATION CONNECTOR]: Enabled local authorization for region {0}",
                 scene.RegionInfo.RegionName);
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Avatar/LocalAvatarServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Avatar/LocalAvatarServiceConnector.cs
@@ -25,9 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using System.Reflection;
-using log4net;
-using Nini.Config;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
@@ -36,13 +37,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 {
     public class LocalAvatarServicesConnector : ISharedRegionModule, IAvatarService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IAvatarService m_AvatarService;
 
@@ -62,6 +63,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalAvatarServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -71,7 +73,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
                     IConfig userConfig = source.Configs["AvatarService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[AVATAR CONNECTOR]: AvatarService missing from OpenSim.ini");
+                        m_logger?.LogError("[AVATAR CONNECTOR]: AvatarService missing from OpenSim.ini");
                         return;
                     }
 
@@ -80,7 +82,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 
                     if (serviceDll.Length == 0)
                     {
-                        m_log.Error("[AVATAR CONNECTOR]: No LocalServiceModule named in section AvatarService");
+                        m_logger?.LogError("[AVATAR CONNECTOR]: No LocalServiceModule named in section AvatarService");
                         return;
                     }
 
@@ -91,11 +93,11 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 
                     if (m_AvatarService == null)
                     {
-                        m_log.Error("[AVATAR CONNECTOR]: Can't load user account service");
+                        m_logger?.LogError("[AVATAR CONNECTOR]: Can't load user account service");
                         return;
                     }
                     m_Enabled = true;
-                    m_log.Info("[AVATAR CONNECTOR]: Local avatar connector enabled");
+                    m_logger?.LogInformation("[AVATAR CONNECTOR]: Local avatar connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Avatar/RemoteAvatarServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Avatar/RemoteAvatarServiceConnector.cs
@@ -25,22 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using Nini.Config;
-using log4net;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 {
     public class RemoteAvatarServicesConnector : AvatarServicesConnector,
             ISharedRegionModule, IAvatarService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
 
@@ -56,6 +57,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 
         public override void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteAvatarServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -73,7 +75,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Avatar
 
                     base.Initialise(source);
 
-                    m_log.Info("[AVATAR CONNECTOR]: Remote avatars enabled");
+                    m_logger?.LogInformation("[AVATAR CONNECTOR]: Remote avatars enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Grid/RegionInfoCache.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Grid/RegionInfoCache.cs
@@ -24,22 +24,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Threading;
+
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-using OpenSim.Framework;
-using OpenMetaverse;
-using log4net;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 using Timer = System.Threading.Timer;
 using ReaderWriterLockSlim = System.Threading.ReaderWriterLockSlim;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using OpenSim.Framework;
+using OpenSim.Server.Base;
+using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+
+using OpenMetaverse;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Grid
 {
     public class RegionInfoCache
     {
-        // private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
+
         private const int CACHE_EXPIRATION_SECONDS = 120; // 2 minutes  opensim regions change a lot
         private const int CACHE_PURGE_TIME = 60000; // milliseconds
         public const ulong HANDLEMASK = 0xffffff00ffffff00ul;

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/ActivityDetector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/ActivityDetector.cs
@@ -24,29 +24,29 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
-using log4net;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 {
     public class ActivityDetector
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IGridUserService m_GridUserService;
 
         public ActivityDetector(IGridUserService guservice)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ActivityDetector>>();
             m_GridUserService = guservice;
-            m_log.DebugFormat("[ACTIVITY DETECTOR]: starting ");
+            m_logger?.LogDebug("[ACTIVITY DETECTOR]: starting ");
         }
 
         public void AddRegion(Scene scene)
@@ -82,7 +82,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
         public void DoOnMakeRootAgent(ScenePresence sp)
         {
             string userid;
-            //m_log.DebugFormat("[ACTIVITY DETECTOR]: Detected root presence {0} in {1}", userid, sp.Scene.RegionInfo.RegionName);
+            //m_logger?.LogDebug("[ACTIVITY DETECTOR]: Detected root presence {0} in {1}", userid, sp.Scene.RegionInfo.RegionName);
             if (sp.Scene.UserManagementModule.GetUserUUI(sp.UUID, out userid))
             {
                 /* we only setposition on known agents that have a valid lookup */

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/LocalGridUserServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/LocalGridUserServiceConnector.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
@@ -35,11 +35,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 {
     public class LocalGridUserServicesConnector : ISharedRegionModule, IGridUserService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IGridUserService m_GridUserService;
 
@@ -61,6 +63,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalGridUserServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -70,7 +73,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
                     IConfig userConfig = source.Configs["GridUserService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[LOCAL GRID USER SERVICE CONNECTOR]: GridUserService missing from OpenSim.ini");
+                        m_logger?.LogError("[LOCAL GRID USER SERVICE CONNECTOR]: GridUserService missing from OpenSim.ini");
                         return;
                     }
 
@@ -78,7 +81,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
                     if (serviceDll.Length == 0)
                     {
-                        m_log.Error("[LOCAL GRID USER SERVICE CONNECTOR]: No LocalServiceModule named in section GridUserService");
+                        m_logger?.LogError("[LOCAL GRID USER SERVICE CONNECTOR]: No LocalServiceModule named in section GridUserService");
                         return;
                     }
 
@@ -87,7 +90,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
                     if (m_GridUserService == null)
                     {
-                        m_log.ErrorFormat(
+                        m_logger?.LogError(
                             "[LOCAL GRID USER SERVICE CONNECTOR]: Cannot load user account service specified as {0}", serviceDll);
                         return;
                     }
@@ -136,7 +139,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
             if (!m_Enabled)
                 return;
 
-            m_log.InfoFormat("[LOCAL GRID USER SERVICE CONNECTOR]: Enabled local grid user for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[LOCAL GRID USER SERVICE CONNECTOR]: Enabled local grid user for region {0}", scene.RegionInfo.RegionName);
         }
 
         #endregion

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/RemoteGridUserServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/GridUser/RemoteGridUserServiceConnector.cs
@@ -24,23 +24,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
 
 using OpenMetaverse;
-using log4net;
+
 using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 {
     public class RemoteGridUserServicesConnector : ISharedRegionModule, IGridUserService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private const int KEEPTIME = 30; // 30 secs
         private ExpiringCacheOS<string, GridUserInfo> m_Infos = new ExpiringCacheOS<string, GridUserInfo>(10000);
@@ -86,6 +89,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteGridUserServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -98,7 +102,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
                     m_ActivityDetector = new ActivityDetector(this);
 
-                    m_log.Info("[REMOTE GRID USER CONNECTOR]: Remote grid user enabled");
+                    m_logger?.LogInformation("[REMOTE GRID USER CONNECTOR]: Remote grid user enabled");
                 }
             }
         }
@@ -119,7 +123,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
             scene.RegisterModuleInterface<IGridUserService>(this);
             m_ActivityDetector.AddRegion(scene);
 
-            m_log.InfoFormat("[REMOTE GRID USER CONNECTOR]: Enabled remote grid user for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[REMOTE GRID USER CONNECTOR]: Enabled remote grid user for region {0}", scene.RegionInfo.RegionName);
 
         }
 
@@ -144,7 +148,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.GridUser
 
         public GridUserInfo LoggedIn(string userID)
         {
-            m_log.Warn("[REMOTE GRID USER CONNECTOR]: LoggedIn not implemented at the simulators");
+            m_logger?.LogWarning("[REMOTE GRID USER CONNECTOR]: LoggedIn not implemented at the simulators");
             return null;
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Land/LocalLandServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Land/LocalLandServiceConnector.cs
@@ -25,22 +25,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using Nini.Config;
-using System.Reflection;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
 using OpenMetaverse;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
 {
     public class LocalLandServicesConnector : ISharedRegionModule, ILandService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger m_logger;
 
         private List<Scene> m_Scenes = new List<Scene>();
 
@@ -48,9 +47,10 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
 
         public LocalLandServicesConnector()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalLandServicesConnector>>();
         }
 
-        public LocalLandServicesConnector(List<Scene> scenes)
+        public LocalLandServicesConnector(List<Scene> scenes) : this()
         {
             m_Scenes = scenes;
         }
@@ -69,6 +69,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalLandServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -76,7 +77,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
                 if (name == Name)
                 {
                     m_Enabled = true;
-                    m_log.Info("[LAND CONNECTOR]: Local land connector enabled");
+                    m_logger?.LogInformation("[LAND CONNECTOR]: Local land connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Land/RemoteLandServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Land/RemoteLandServiceConnector.cs
@@ -25,15 +25,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using System.Reflection;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Services.Connectors;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
 using OpenMetaverse;
+
+using Nini.Config;
 
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
@@ -41,9 +45,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
     public class RemoteLandServicesConnector :
             LandServicesConnector, ISharedRegionModule, ILandService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger m_logger;
 
         private bool m_Enabled = false;
         private LocalLandServicesConnector m_LocalService;
@@ -60,6 +62,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteLandServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -70,7 +73,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Land
 
                     m_Enabled = true;
 
-                    m_log.Info("[LAND CONNECTOR]: Remote Land connector enabled");
+                    m_logger?.LogInformation("[LAND CONNECTOR]: Remote Land connector enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/MuteList/LocalMuteListServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/MuteList/LocalMuteListServiceConnector.cs
@@ -25,23 +25,24 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using Nini.Config;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Server.Base;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
+
 using OpenMetaverse;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
 {
     public class LocalMuteListServicesConnector : ISharedRegionModule, IMuteListService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger m_logger;
 
         private List<Scene> m_Scenes = new List<Scene>();
         protected IMuteListService m_service = null;
@@ -62,6 +63,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalMuteListServicesConnector>>();
             // only active for core mute lists module
             IConfig moduleConfig = source.Configs["Messaging"];
             if (moduleConfig == null)
@@ -82,7 +84,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
             IConfig userConfig = source.Configs["MuteListService"];
             if (userConfig == null)
             {
-                m_log.Error("[MuteList LOCALCONNECTOR]: MuteListService missing from configuration");
+                m_logger?.LogError("[MuteList LOCALCONNECTOR]: MuteListService missing from configuration");
                 return;
             }
 
@@ -91,7 +93,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
 
             if (serviceDll.Length == 0)
             {
-                m_log.Error("[MuteList LOCALCONNECTOR]: No LocalServiceModule named in section MuteListService");
+                m_logger?.LogError("[MuteList LOCALCONNECTOR]: No LocalServiceModule named in section MuteListService");
                 return;
             }
 
@@ -102,18 +104,18 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
             }
             catch
             {
-                m_log.Error("[MuteList LOCALCONNECTOR]: Failed to load mute service");
+                m_logger?.LogError("[MuteList LOCALCONNECTOR]: Failed to load mute service");
                 return;
             }
 
             if (m_service == null)
             {
-                m_log.Error("[MuteList LOCALCONNECTOR]: Can't load MuteList service");
+                m_logger?.LogError("[MuteList LOCALCONNECTOR]: Can't load MuteList service");
                 return;
             }
 
             m_Enabled = true;
-            m_log.Info("[MuteList LOCALCONNECTOR]: enabled");
+            m_logger?.LogInformation("[MuteList LOCALCONNECTOR]: enabled");
         }
 
         public void Close()

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/MuteList/RemoteMuteListServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/MuteList/RemoteMuteListServiceConnector.cs
@@ -24,22 +24,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
 
 using OpenMetaverse;
-using log4net;
+
 using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
 {
     public class RemoteMuteListServicesConnector : ISharedRegionModule, IMuteListService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         #region ISharedRegionModule
 
@@ -59,6 +63,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteMuteListServicesConnector>>();
            // only active for core mute lists module
             IConfig moduleConfig = source.Configs["Messaging"];
             if (moduleConfig == null)
@@ -93,7 +98,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.MuteList
                 return;
 
             scene.RegisterModuleInterface<IMuteListService>(this);
-            m_log.InfoFormat("[MUTELIST CONNECTOR]: Enabled for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[MUTELIST CONNECTOR]: Enabled for region {0}", scene.RegionInfo.RegionName);
         }
 
         public void RemoveRegion(Scene scene)

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Neighbour/NeighbourServiceOutConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Neighbour/NeighbourServiceOutConnector.cs
@@ -25,14 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
 using System.Reflection;
-using Nini.Config;
 using OpenSim.Framework;
 using OpenSim.Services.Connectors;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
+using Nini.Config;
 
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Neighbour
@@ -40,9 +41,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Neighbour
     public class NeighbourServicesOutConnector :
             NeighbourServicesConnector, ISharedRegionModule, INeighbourService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger m_logger;
 
         private List<Scene> m_Scenes = new List<Scene>();
         private bool m_Enabled = false;
@@ -59,6 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Neighbour
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<NeighbourServicesOutConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -66,7 +66,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Neighbour
                 if (name == Name)
                 {
                     m_Enabled = true;
-                    m_log.Info("[NEIGHBOUR CONNECTOR]: Neighbour out connector enabled");
+                    m_logger?.LogInformation("[NEIGHBOUR CONNECTOR]: Neighbour out connector enabled");
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Neighbour
                 return;
 
             m_GridService = scene.GridService;
-            m_log.InfoFormat("[NEIGHBOUR CONNECTOR]: Enabled out neighbours for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[NEIGHBOUR CONNECTOR]: Enabled out neighbours for region {0}", scene.RegionInfo.RegionName);
 
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/BasePresenceServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/BasePresenceServiceConnector.cs
@@ -25,10 +25,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using PresenceInfo = OpenSim.Services.Interfaces.PresenceInfo;
 
@@ -36,7 +38,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 {
     public class BasePresenceServiceConnector : IPresenceService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger m_logger;
 
         protected bool m_Enabled;
 
@@ -63,7 +65,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
             scene.RegisterModuleInterface<IPresenceService>(this);
             m_PresenceDetector.AddRegion(scene);
 
-            m_log.InfoFormat("[BASE PRESENCE SERVICE CONNECTOR]: Enabled for region {0}", scene.Name);
+            m_logger?.LogInformation("[BASE PRESENCE SERVICE CONNECTOR]: Enabled for region {0}", scene.Name);
         }
 
         public void RemoveRegion(Scene scene)
@@ -93,7 +95,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 
         public bool LoginAgent(string userID, UUID sessionID, UUID secureSessionID)
         {
-            m_log.Warn("[BASE PRESENCE SERVICE CONNECTOR]: LoginAgent connector not implemented at the simulators");
+            m_logger?.LogWarning("[BASE PRESENCE SERVICE CONNECTOR]: LoginAgent connector not implemented at the simulators");
             return false;
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/PresenceDetector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/PresenceDetector.cs
@@ -24,26 +24,29 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using log4net;
-using OpenMetaverse;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
+using OpenMetaverse;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 {
     public class PresenceDetector
     {
-//        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IPresenceService m_PresenceService;
         private Scene m_aScene;
 
         public PresenceDetector(IPresenceService presenceservice)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<PresenceDetector>>();
             m_PresenceService = presenceservice;
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/RemotePresenceServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Presence/RemotePresenceServiceConnector.cs
@@ -24,18 +24,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 using OpenSim.Services.Connectors;
-using log4net;
+
 using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 {
     public class RemotePresenceServicesConnector : BasePresenceServiceConnector, ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         #region ISharedRegionModule
 
@@ -46,6 +49,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemotePresenceServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -58,7 +62,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
 
                     m_PresenceDetector = new PresenceDetector(this);
 
-                    m_log.Info("[REMOTE PRESENCE CONNECTOR]: Remote presence enabled");
+                    m_logger?.LogInformation("[REMOTE PRESENCE CONNECTOR]: Remote presence enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Simulation/RemoteSimulationConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/Simulation/RemoteSimulationConnector.cs
@@ -25,15 +25,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
-using OpenMetaverse;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors.Simulation;
+
+using OpenMetaverse;
+
+using Nini.Config;
 
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 
@@ -41,7 +45,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation
 {
     public class RemoteSimulationConnectorModule : ISharedRegionModule, ISimulationService
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool initialized = false;
         protected bool m_enabled = false;
@@ -56,6 +60,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation
 
         public virtual void Initialise(IConfiguration configSource)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteSimulationConnectorModule>>();
             IConfig moduleConfig = configSource.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -70,7 +75,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation
 
                     m_enabled = true;
 
-                    m_log.Info("[REMOTE SIMULATION CONNECTOR]: Remote simulation enabled.");
+                    m_logger?.LogInformation("[REMOTE SIMULATION CONNECTOR]: Remote simulation enabled.");
                 }
             }
         }
@@ -156,7 +161,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation
             if (destination == null)
             {
                 reason = "Given destination was null";
-                m_log.DebugFormat("[REMOTE SIMULATION CONNECTOR]: CreateAgent was given a null destination");
+                m_logger?.LogDebug("[REMOTE SIMULATION CONNECTOR]: CreateAgent was given a null destination");
                 return false;
             }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/LocalUserAccountServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/LocalUserAccountServiceConnector.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
@@ -35,13 +35,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 {
     public class LocalUserAccountServicesConnector : ISharedRegionModule, IUserAccountService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         /// <summary>
         /// This is not on the IUserAccountService.  It's only being used so that standalone scenes can punch through
@@ -67,6 +67,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalUserAccountServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -76,7 +77,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
                     IConfig userConfig = source.Configs["UserAccountService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: UserAccountService missing from OpenSim.ini");
+                        m_logger?.LogError("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: UserAccountService missing from OpenSim.ini");
                         return;
                     }
 
@@ -84,7 +85,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 
                     if (serviceDll.Length == 0)
                     {
-                        m_log.Error("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: No LocalServiceModule named in section UserService");
+                        m_logger?.LogError("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: No LocalServiceModule named in section UserService");
                         return;
                     }
 
@@ -93,14 +94,14 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 
                     if (UserAccountService == null)
                     {
-                        m_log.ErrorFormat(
+                        m_logger?.LogError(
                             "[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Cannot load user account service specified as {0}", serviceDll);
                         return;
                     }
                     m_Enabled = true;
                     m_Cache = new UserAccountCache();
 
-                    m_log.Info("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Local user connector enabled");
+                    m_logger?.LogInformation("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Local user connector enabled");
                 }
             }
         }
@@ -139,7 +140,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
             if (!m_Enabled)
                 return;
 
-            m_log.InfoFormat("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Enabled local user accounts for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Enabled local user accounts for region {0}", scene.RegionInfo.RegionName);
         }
 
         #endregion

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/RemoteUserAccountServiceConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/RemoteUserAccountServiceConnector.cs
@@ -25,25 +25,27 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using Nini.Config;
-using log4net;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
 using OpenSim.Framework;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 {
     public class RemoteUserAccountServicesConnector : UserAccountServicesConnector,
             ISharedRegionModule, IUserAccountService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
         private UserAccountCache m_Cache;
@@ -60,6 +62,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 
         public override void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteUserAccountServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -69,7 +72,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
                     IConfig userConfig = source.Configs["UserAccountService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[USER CONNECTOR]: UserAccountService missing from OpenSim.ini");
+                        m_logger?.LogError("[USER CONNECTOR]: UserAccountService missing from OpenSim.ini");
                         return;
                     }
 
@@ -78,7 +81,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
                     base.Initialise(source);
                     m_Cache = new UserAccountCache();
 
-                    m_log.Info("[USER CONNECTOR]: Remote users enabled");
+                    m_logger?.LogInformation("[USER CONNECTOR]: Remote users enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/UserAccountCache.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAccounts/UserAccountCache.cs
@@ -24,13 +24,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Reflection;
-using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
 using OpenMetaverse;
-using log4net;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 {
@@ -40,7 +41,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
         private const int CACHE_EXPIRATION_SECONDS = 3600; // 1 hour!
         private const int CACHE_NULL_EXPIRATION_SECONDS = 600; // 10minutes
 
-        //private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         //5min expire checks
         private ExpiringCacheOS<UUID, UserAccount> m_UUIDCache = new ExpiringCacheOS<UUID, UserAccount>(300000);

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAliases/LocalUserAliasServicesConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAliases/LocalUserAliasServicesConnector.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Server.Base;
@@ -35,13 +35,13 @@ using OpenSim.Services.Interfaces;
 
 using OpenMetaverse;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 {
     public class LocalUserAliasServicesConnector : ISharedRegionModule, IUserAliasService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public IUserAliasService UserAliasService { get; private set; }
 
@@ -61,6 +61,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LocalUserAliasServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -70,7 +71,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
                     IConfig userConfig = source.Configs["UserAliasService"];
                     if (userConfig == null)
                     {
-                        m_log.Error("[LOCAL USER ALIAS SERVICE CONNECTOR]: UserAliasService missing from OpenSim.ini");
+                        m_logger?.LogError("[LOCAL USER ALIAS SERVICE CONNECTOR]: UserAliasService missing from OpenSim.ini");
                         return;
                     }
 
@@ -78,7 +79,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 
                     if (serviceDll.Length == 0)
                     {
-                        m_log.Error("[LOCAL USER ALIAS SERVICE CONNECTOR]: No LocalServiceModule named in section UserAliasService");
+                        m_logger?.LogError("[LOCAL USER ALIAS SERVICE CONNECTOR]: No LocalServiceModule named in section UserAliasService");
                         return;
                     }
 
@@ -87,14 +88,14 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 
                     if (UserAliasService == null)
                     {
-                        m_log.ErrorFormat(
+                        m_logger?.LogError(
                             "[USER ALIAS SERVICE CONNECTOR]: Cannot load user account alias specified as {0}", serviceDll);
                         return;
                     }
 
                     m_Enabled = true;
 
-                    m_log.Info("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Local user connector enabled");
+                    m_logger?.LogInformation("[LOCAL USER ACCOUNT SERVICE CONNECTOR]: Local user connector enabled");
                 }
             }
         }
@@ -130,7 +131,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
             if (!m_Enabled)
                 return;
 
-            m_log.InfoFormat("[LOCAL USER ALIAS SERVICE CONNECTOR]: Enabled local user aliases for region {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[LOCAL USER ALIAS SERVICE CONNECTOR]: Enabled local user aliases for region {0}", scene.RegionInfo.RegionName);
         }
 
         #endregion

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAliases/RemoteUserAliasServicesConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsOut/UserAliases/RemoteUserAliasServicesConnector.cs
@@ -25,23 +25,24 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using Nini.Config;
-using log4net;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors;
 using OpenSim.Framework;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 {
     public class RemoteUserAliasServicesConnector : UserAliasServicesConnector,
             ISharedRegionModule, IUserAliasService
     {
-        private static readonly ILog m_log =
-                LogManager.GetLogger(
-                MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
 
@@ -57,6 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 
         public override void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteUserAliasServicesConnector>>();
             IConfig moduleConfig = source.Configs["Modules"];
             if (moduleConfig != null)
             {
@@ -74,7 +76,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAliases
 
                     base.Initialise(source);
 
-                    m_log.Info("[USER CONNECTOR]: Remote user aliases enabled");
+                    m_logger?.LogInformation("[USER CONNECTOR]: Remote user aliases enabled");
                 }
             }
         }

--- a/Source/OpenSim.Region.CoreModules/World/Archiver/AssetsArchiver.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Archiver/AssetsArchiver.cs
@@ -25,14 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Xml;
-using log4net;
-using OpenMetaverse;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Serialization;
+using OpenSim.Server.Base;
+
+using OpenMetaverse;
 
 namespace OpenSim.Region.CoreModules.World.Archiver
 {
@@ -41,7 +41,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
     /// </summary>
     public class AssetsArchiver
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         /// <value>
         /// Post a message to the log every x assets as a progress bar
@@ -57,6 +57,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
         public AssetsArchiver(TarArchiveWriter archiveWriter)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<AssetsArchiver>>();
             m_archiveWriter = archiveWriter;
         }
 
@@ -131,7 +132,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             }
             else
             {
-                m_log.Error(
+                m_logger?.LogError(
                     $"[ARCHIVER]: Unrecognized asset type {asset.Type} with uuid {asset.ID}. This asset will be saved but may not load");
                 m_archiveWriter.WriteFile($"{ArchiveConstants.ASSETS_PATH}{asset.FullID}", asset.Data);
             }
@@ -139,7 +140,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
             m_assetsWritten++;
 
             if (m_assetsWritten % LOG_ASSET_LOAD_NOTIFICATION_INTERVAL == 0)
-                m_log.Info($"[ARCHIVER]: Added {m_assetsWritten} assets to archive");
+                m_logger?.LogInformation($"[ARCHIVER]: Added {m_assetsWritten} assets to archive");
         }
     }
 }

--- a/Source/OpenSim.Region.CoreModules/World/Archiver/DearchiveScenesGroup.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Archiver/DearchiveScenesGroup.cs
@@ -25,16 +25,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using OpenSim.Region.Framework.Scenes;
-using OpenMetaverse;
 using System.Drawing;
-using log4net;
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using OpenMetaverse;
+
+using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework.Serialization;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.CoreModules.World.Archiver
 {
@@ -43,7 +43,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
     /// </summary>
     public class DearchiveScenesInfo
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         /// <summary>
         /// One region in the archive.
@@ -108,6 +108,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
 
         public DearchiveScenesInfo()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DearchiveScenesInfo>>();
             MultiRegionFormat = false;
         }
 
@@ -179,7 +180,7 @@ namespace OpenSim.Region.CoreModules.World.Archiver
                 }
                 else
                 {
-                    m_log.WarnFormat("[ARCHIVER]: Not loading archived region {0} because there's no existing region at location {1},{2}",
+                    m_logger?.LogWarning("[ARCHIVER]: Not loading archived region {0} because there's no existing region at location {1},{2}",
                         archivedRegion.Directory, location.X, location.Y);
                 }
             }

--- a/Source/OpenSim.Region.CoreModules/World/Estate/EstateConnector.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Estate/EstateConnector.cs
@@ -25,25 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using OpenMetaverse;
 
 using OpenSim.Services.Interfaces;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 using OpenSim.Server.Base;
-using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 
-using OpenMetaverse;
-using log4net;
 
 namespace OpenSim.Region.CoreModules.World.Estate
 {
     public class EstateConnector
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected EstateModule m_EstateModule;
         private string token;
@@ -51,6 +49,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
 
         public EstateConnector(EstateModule module, string _token, uint _port)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<EstateConnector>>();
             m_EstateModule = module;
             token = _token;
             port = _port;
@@ -187,7 +186,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
         private bool Call(GridRegion region, Dictionary<string, object> sendData)
         {
             string reqString = ServerUtils.BuildQueryString(sendData);
-            // m_log.DebugFormat("[ESTATE CONNECTOR]: queryString = {0}", reqString);
+            // m_logger?.LogDebug("[ESTATE CONNECTOR]: queryString = {0}", reqString);
             try
             {
                 //string url = "";
@@ -207,11 +206,11 @@ namespace OpenSim.Region.CoreModules.World.Estate
                         return indx > 0;
                 }
                 else
-                    m_log.DebugFormat("[ESTATE CONNECTOR]: received empty reply");
+                    m_logger?.LogDebug("[ESTATE CONNECTOR]: received empty reply");
             }
             catch (Exception e)
             {
-                m_log.DebugFormat("[ESTATE CONNECTOR]: Exception when contacting remote sim: {0}", e.Message);
+                m_logger?.LogDebug("[ESTATE CONNECTOR]: Exception when contacting remote sim: {0}", e.Message);
             }
 
             return false;

--- a/Source/OpenSim.Region.CoreModules/World/Estate/EstateManagementCommands.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Estate/EstateManagementCommands.cs
@@ -25,21 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Security;
 using System.Text;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
-using OpenSim.Framework.Console;
-using OpenSim.Region.CoreModules.Framework.InterfaceCommander;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Estate
 {
@@ -48,7 +44,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
     /// </summary>
     public class EstateManagementCommands
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected EstateManagementModule m_module;
 
@@ -59,6 +55,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
 
         public void Initialise()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<EstateManagementCommands>>();
 //            m_log.DebugFormat("[ESTATE MODULE]: Setting up estate commands for region {0}", m_module.Scene.RegionInfo.RegionName);
 
             m_module.Scene.AddCommand("Regions", m_module, "set terrain texture",
@@ -102,7 +99,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
                     int corner = int.Parse(num);
                     UUID texture = UUID.Parse(uuid);
 
-                    m_log.Debug("[ESTATEMODULE]: Setting terrain textures for " + m_module.Scene.RegionInfo.RegionName +
+                    m_logger?.LogDebug("[ESTATEMODULE]: Setting terrain textures for " + m_module.Scene.RegionInfo.RegionName +
                                 string.Format(" (C#{0} = {1})", corner, texture));
 
                     switch (corner)
@@ -140,7 +137,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
                 {
                     double selectedheight = double.Parse(heightstring);
 
-                    m_log.Debug("[ESTATEMODULE]: Setting water height in " + m_module.Scene.RegionInfo.RegionName + " to " +
+                    m_logger?.LogDebug("[ESTATEMODULE]: Setting water height in " + m_module.Scene.RegionInfo.RegionName + " to " +
                                 string.Format(" {0}", selectedheight));
                     m_module.Scene.RegionInfo.RegionSettings.WaterHeight = selectedheight;
 
@@ -166,7 +163,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
                     float lowValue = float.Parse(min, Culture.NumberFormatInfo);
                     float highValue = float.Parse(max, Culture.NumberFormatInfo);
 
-                    m_log.Debug("[ESTATEMODULE]: Setting terrain heights " + m_module.Scene.RegionInfo.RegionName +
+                    m_logger?.LogDebug("[ESTATEMODULE]: Setting terrain heights " + m_module.Scene.RegionInfo.RegionName +
                                 string.Format(" (C{0}, {1}-{2}", corner, lowValue, highValue));
 
                     switch (corner)

--- a/Source/OpenSim.Region.CoreModules/World/Estate/EstateModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Estate/EstateModule.cs
@@ -25,21 +25,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework.Servers;
 using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Estate
 {
     public class EstateModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected List<Scene> m_Scenes = new List<Scene>();
         protected bool m_InInfoUpdate = false;
@@ -61,6 +65,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<EstateModule>>();
             uint port = MainServer.Instance.Port;
 
             IConfig estateConfig = config.Configs["Estates"];

--- a/Source/OpenSim.Region.CoreModules/World/Estate/EstateRequestHandler.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Estate/EstateRequestHandler.cs
@@ -25,27 +25,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Reflection;
 using System.Xml;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
-using OpenSim.Server.Base;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 
 using OpenMetaverse;
-using log4net;
 
 namespace OpenSim.Region.CoreModules.World.Estate
 {
     public class EstateSimpleRequestHandler :SimpleStreamHandler
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected EstateModule m_EstateModule;
         protected Object m_RequestLock = new Object();
@@ -53,6 +51,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
 
         public EstateSimpleRequestHandler(EstateModule fmodule, string _token) : base("/estate")
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<EstateSimpleRequestHandler>>();
             m_EstateModule = fmodule;
             token = _token;
         }
@@ -138,7 +137,7 @@ namespace OpenSim.Region.CoreModules.World.Estate
             }
             catch (Exception e)
             {
-                m_log.Debug("[ESTATE]: Exception {0}" + e.ToString());
+                m_logger?.LogDebug("[ESTATE]: Exception {0}" + e.ToString());
             }
 
             httpResponse.RawBuffer = FailureResult();

--- a/Source/OpenSim.Region.CoreModules/World/Estate/TelehubManager.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Estate/TelehubManager.cs
@@ -25,24 +25,26 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
-using System.Collections.Generic;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
-using log4net;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.CoreModules.World.Estate
 {
     public class TelehubManager
     {
-        // private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
 
         Scene m_Scene;
 
         public TelehubManager(Scene scene)
         {
+            // m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<TelehubManager>>();
             m_Scene = scene;
         }
 

--- a/Source/OpenSim.Region.CoreModules/World/Land/LandObject.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Land/LandObject.cs
@@ -25,17 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
-using log4net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using RegionFlags = OpenMetaverse.RegionFlags;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.CoreModules.World.Land
 {
@@ -46,7 +47,7 @@ namespace OpenSim.Region.CoreModules.World.Land
     {
         #region Member Variables
 
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static readonly string LogHeader = "[LAND OBJECT]";
 
         protected const int GROUPMEMBERCACHETIMEOUT = 30000;  // cache invalidation after 30s
@@ -324,6 +325,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public LandObject(LandData landData, Scene scene)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LandObject>>();
             LandData = landData.Copy();
             m_scene = scene;
             m_scenePermissions = scene.Permissions;
@@ -340,6 +342,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public LandObject(UUID owner_id, bool is_group_owned, Scene scene, LandData data = null)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LandObject>>();
             m_scene = scene;
             if (m_scene == null)
             {
@@ -455,7 +458,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 if(parcelMax > m_regionInfo.ObjectCapacity)
                     parcelMax = m_regionInfo.ObjectCapacity;
 
-                //m_log.DebugFormat("Area: {0}, Capacity {1}, Bonus {2}, Parcel {3}", LandData.Area, m_regionInfo.ObjectCapacity, m_regionInfo.RegionSettings.ObjectBonus, parcelMax);
+                //m_logger?.LogDebug("Area: {0}, Capacity {1}, Bonus {2}, Parcel {3}", LandData.Area, m_regionInfo.ObjectCapacity, m_regionInfo.RegionSettings.ObjectBonus, parcelMax);
                 return parcelMax;
             }
         }
@@ -479,7 +482,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 // sanity check
                 if(simMax > m_regionInfo.ObjectCapacity)
                     simMax = m_regionInfo.ObjectCapacity;
-                 //m_log.DebugFormat("Simwide Area: {0}, Capacity {1}, SimMax {2}, SimWidePrims {3}",
+                 //m_logger?.LogDebug("Simwide Area: {0}, Capacity {1}, SimMax {2}, SimWidePrims {3}",
                  //    LandData.SimwideArea, m_regionInfo.ObjectCapacity, simMax, LandData.SimwidePrims);
                 return simMax;
             }
@@ -1333,7 +1336,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 }
             }
 
-            // m_log.DebugFormat("{0} ModifyLandBitmapSquare. startXY=<{1},{2}>, endXY=<{3},{4}>, val={5}, landBitmapSize=<{6},{7}>",
+            // m_logger?.LogDebug("{0} ModifyLandBitmapSquare. startXY=<{1},{2}>, endXY=<{3},{4}>, val={5}, landBitmapSize=<{6},{7}>",
             //                         LogHeader, start_x, start_y, end_x, end_y, set_value, land_bitmap.GetLength(0), land_bitmap.GetLength(1));
             return land_bitmap;
         }
@@ -1441,7 +1444,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                         }
                         catch (Exception)   //just in case we've still not taken care of every way the arrays might go out of bounds! ;)
                         {
-                            m_log.DebugFormat("{0} RemapLandBitmap Rotate: Out of Bounds sx={1} sy={2} dx={3} dy={4}", LogHeader, sx, sy, x, y);
+                            m_logger?.LogDebug("{0} RemapLandBitmap Rotate: Out of Bounds sx={1} sy={2} dx={3} dy={4}", LogHeader, sx, sy, x, y);
                         }
                     }
                 }
@@ -1474,7 +1477,7 @@ namespace OpenSim.Region.CoreModules.World.Land
             if (endY > tmpY) endY = tmpY;
             if (endY < 0) endY = 0;
 
-            //m_log.DebugFormat("{0} RemapLandBitmap: inSize=<{1},{2}>, disp=<{3},{4}> rot={5}, offset=<{6},{7}>, boundingStart=<{8},{9}>, boundingEnd=<{10},{11}>, cosR={12}, sinR={13}, outSize=<{14},{15}>", LogHeader,
+            //m_logger?.LogDebug("{0} RemapLandBitmap: inSize=<{1},{2}>, disp=<{3},{4}> rot={5}, offset=<{6},{7}>, boundingStart=<{8},{9}>, boundingEnd=<{10},{11}>, cosR={12}, sinR={13}, outSize=<{14},{15}>", LogHeader,
             //                            baseX, baseY, dispX, dispY, radianRotation, offsetX, offsetY, startX, startY, endX, endY, cosR, sinR, newX, newY);
 
             isEmptyNow = true;
@@ -1498,7 +1501,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                         }
                         catch (Exception)   //just in case we've still not taken care of every way the arrays might go out of bounds! ;)
                         {
-                            m_log.DebugFormat("{0} RemapLandBitmap - Bound & Displace: Out of Bounds sx={1} sy={2} dx={3} dy={4}", LogHeader, x, y, dx, dy);
+                            m_logger?.LogDebug("{0} RemapLandBitmap - Bound & Displace: Out of Bounds sx={1} sy={2} dx={3} dy={4}", LogHeader, x, y, dx, dy);
                         }
                     }
                 }
@@ -1612,7 +1615,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                     xLen = (int)(Constants.RegionSize / Constants.LandUnit);
                 }
             }
-            // m_log.DebugFormat("{0} ConvertBytesToLandBitmap: bitmapLen={1}, xLen={2}", LogHeader, bitmapLen, xLen);
+            // m_logger?.LogDebug("{0} ConvertBytesToLandBitmap: bitmapLen={1}, xLen={2}", LogHeader, bitmapLen, xLen);
 
             byte tempByte;
             int x = 0, y = 0;
@@ -1628,7 +1631,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                     }
                     catch (Exception)
                     {
-                        m_log.DebugFormat("{0} ConvertBytestoLandBitmap: i={1}, x={2}, y={3}", LogHeader, i, x, y);
+                        m_logger?.LogDebug("{0} ConvertBytestoLandBitmap: i={1}, x={2}, y={3}", LogHeader, i, x, y);
                     }
                     x++;
                     if (x >= xLen)
@@ -1656,7 +1659,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public void DebugLandBitmap(bool[,] landBitmap)
         {
-            m_log.InfoFormat("{0}: Map Key: #=claimed land .=unclaimed land.", LogHeader);
+            m_logger?.LogInformation("{0}: Map Key: #=claimed land .=unclaimed land.", LogHeader);
             for (int y = landBitmap.GetLength(1) - 1; y >= 0; y--)
             {
                 string row = "";
@@ -1664,7 +1667,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 {
                     row += landBitmap[x, y] ? "#" : ".";
                 }
-                m_log.InfoFormat("{0}: {1}", LogHeader, row);
+                m_logger?.LogInformation("{0}: {1}", LogHeader, row);
             }
         }
 
@@ -1706,7 +1709,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                     }
                 } catch (InvalidOperationException)
                 {
-                    m_log.Error("[LAND]: Unable to force select the parcel objects. Arr.");
+                    m_logger?.LogError("[LAND]: Unable to force select the parcel objects. Arr.");
                 }
 
                 remote_client.SendForceClientSelectObjects(resultLocalIDs);
@@ -1730,7 +1733,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
                 lock (primsOverMe)
                 {
-                    //m_log.DebugFormat(
+                    //m_logger?.LogDebug(
                     //    "[LAND OBJECT]: Request for SendLandObjectOwners() from {0} with {1} known prims on region",
                     //    remote_client.Name, primsOverMe.Count);
 
@@ -1747,7 +1750,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                             }
                             catch (NullReferenceException)
                             {
-                                m_log.Error("[LAND]: " + "Got Null Reference when searching land owners from the parcel panel");
+                                m_logger?.LogError("[LAND]: " + "Got Null Reference when searching land owners from the parcel panel");
                             }
                             try
                             {
@@ -1755,7 +1758,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                             }
                             catch (KeyNotFoundException)
                             {
-                                m_log.Error("[LAND]: Unable to match a prim with it's owner.");
+                                m_logger?.LogError("[LAND]: Unable to match a prim with it's owner.");
                             }
                             if (obj.OwnerID.Equals(obj.GroupID) && (!groups.Contains(obj.OwnerID)))
                                 groups.Add(obj.OwnerID);
@@ -1763,7 +1766,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                     }
                     catch (InvalidOperationException)
                     {
-                        m_log.Error("[LAND]: Unable to Enumerate Land object arr.");
+                        m_logger?.LogError("[LAND]: Unable to Enumerate Land object arr.");
                     }
                 }
 
@@ -1791,7 +1794,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 }
                 catch (InvalidOperationException)
                 {
-                    m_log.Error("[LAND]: Unable to enumerate land owners. arr.");
+                    m_logger?.LogError("[LAND]: Unable to enumerate land owners. arr.");
                 }
 
             }
@@ -1804,7 +1807,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public void SellLandObjects(UUID previousOwner)
         {
-            // m_log.DebugFormat(
+            // m_logger?.LogDebug(
             //    "[LAND OBJECT]: Request to sell objects in {0} from {1}", LandData.Name, previousOwner);
 
             if (LandData.IsGroupOwned)
@@ -1813,13 +1816,13 @@ namespace OpenSim.Region.CoreModules.World.Land
             IBuySellModule m_BuySellModule = m_scene.RequestModuleInterface<IBuySellModule>();
             if (m_BuySellModule == null)
             {
-                m_log.Error("[LAND OBJECT]: BuySellModule not found");
+                m_logger?.LogError("[LAND OBJECT]: BuySellModule not found");
                 return;
             }
 
             if (!m_scene.TryGetScenePresence(LandData.OwnerID, out ScenePresence sp))
             {
-                m_log.Error("[LAND OBJECT]: New owner is not present in scene");
+                m_logger?.LogError("[LAND OBJECT]: New owner is not present in scene");
                 return;
             }
 
@@ -1845,7 +1848,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public void ReturnLandObjects(uint type, UUID[] owners, UUID[] tasks, IClientAPI remote_client)
         {
-            //m_log.DebugFormat(
+            //m_logger?.LogDebug(
             //    "[LAND OBJECT]: Request to return objects in {0} from {1}", LandData.Name, remote_client.Name);
 
             Dictionary<UUID,List<SceneObjectGroup>> returns = new();
@@ -1932,7 +1935,7 @@ namespace OpenSim.Region.CoreModules.World.Land
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddPrimOverMe(SceneObjectGroup obj)
         {
-//            m_log.DebugFormat("[LAND OBJECT]: Adding scene object {0} {1} over {2}", obj.Name, obj.LocalId, LandData.Name);
+//            m_logger?.LogDebug("[LAND OBJECT]: Adding scene object {0} {1} over {2}", obj.Name, obj.LocalId, LandData.Name);
 
             lock (primsOverMe)
                 primsOverMe.Add(obj);
@@ -1941,7 +1944,7 @@ namespace OpenSim.Region.CoreModules.World.Land
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemovePrimFromOverMe(SceneObjectGroup obj)
         {
-            //m_log.DebugFormat("[LAND OBJECT]: Removing scene object {0} {1} from over {2}", obj.Name, obj.LocalId, LandData.Name);
+            //m_logger?.LogDebug("[LAND OBJECT]: Removing scene object {0} {1} from over {2}", obj.Name, obj.LocalId, LandData.Name);
             lock (primsOverMe)
                 primsOverMe.Remove(obj);
         }
@@ -1965,7 +1968,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 }
                 catch (Exception e)
                 {
-                    m_log.ErrorFormat("[LAND OBJECT]: SetMediaUrl error: {0}", e.Message);
+                    m_logger?.LogError("[LAND OBJECT]: SetMediaUrl error: {0}", e.Message);
                     return;
                 }
             }
@@ -1990,7 +1993,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                 }
                 catch (Exception e)
                 {
-                    m_log.ErrorFormat("[LAND OBJECT]: SetMusicUrl error: {0}", e.Message);
+                    m_logger?.LogError("[LAND OBJECT]: SetMusicUrl error: {0}", e.Message);
                     return;
                 }
             }
@@ -2075,7 +2078,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                         presence.ControllingClient.SendAlertMessage("You have been ejected from this land");
                     }
                 }
-                m_log.DebugFormat("[LAND]: Removing entry {0} because it has expired", entry.AgentID);
+                m_logger?.LogDebug("[LAND]: Removing entry {0} because it has expired", entry.AgentID);
             }
 
             if (delete.Count > 0)

--- a/Source/OpenSim.Region.CoreModules/World/LegacyMap/ShadedMapTileRenderer.cs
+++ b/Source/OpenSim.Region.CoreModules/World/LegacyMap/ShadedMapTileRenderer.cs
@@ -25,20 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
 using System.Drawing;
-using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.LegacyMap
 {
     public class ShadedMapTileRenderer : IMapTileTerrainRenderer
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static readonly string LogHeader = "[SHADED MAPTILE RENDERER]";
 
         private Scene m_scene;
@@ -47,6 +50,7 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
 
         public void Initialise(Scene scene, IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ShadedMapTileRenderer>>();
             m_scene = scene;
             m_config = config;
 
@@ -56,14 +60,14 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
 
         public void TerrainToBitmap(Bitmap mapbmp)
         {
-            m_log.DebugFormat("{0} Generating Maptile Step 1: Terrain", LogHeader);
+            m_logger?.LogDebug("{0} Generating Maptile Step 1: Terrain", LogHeader);
             int tc = Environment.TickCount;
 
             ITerrainChannel hm = m_scene.Heightmap;
 
             if (mapbmp.Width != hm.Width || mapbmp.Height != hm.Height)
             {
-                m_log.ErrorFormat("{0} TerrainToBitmap. Passed bitmap wrong dimensions. passed=<{1},{2}>, size=<{3},{4}>",
+                m_logger?.LogError("{0} TerrainToBitmap. Passed bitmap wrong dimensions. passed=<{1},{2}>, size=<{3},{4}>",
                     LogHeader, mapbmp.Width, mapbmp.Height, hm.Width, hm.Height);
             }
 
@@ -159,7 +163,7 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
                                 }
                                 catch (OverflowException)
                                 {
-                                    m_log.Debug("[MAPTILE]: Shadow failed at value: " + hfdiff.ToString());
+                                    m_logger?.LogDebug("[MAPTILE]: Shadow failed at value: " + hfdiff.ToString());
                                     ShadowDebugContinue = false;
                                 }
 
@@ -209,7 +213,7 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
                         {
                             if (!terraincorruptedwarningsaid)
                             {
-                                m_log.WarnFormat("[SHADED MAP TILE RENDERER]: Your terrain is corrupted in region {0}, it might take a few minutes to generate the map image depending on the corruption level", m_scene.RegionInfo.RegionName);
+                                m_logger?.LogWarning("[SHADED MAP TILE RENDERER]: Your terrain is corrupted in region {0}, it might take a few minutes to generate the map image depending on the corruption level", m_scene.RegionInfo.RegionName);
                                 terraincorruptedwarningsaid = true;
                             }
                             color = Color.Black;
@@ -239,7 +243,7 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
                         {
                             if (!terraincorruptedwarningsaid)
                             {
-                                m_log.WarnFormat("[SHADED MAP TILE RENDERER]: Your terrain is corrupted in region {0}, it might take a few minutes to generate the map image depending on the corruption level", m_scene.RegionInfo.RegionName);
+                                m_logger?.LogWarning("[SHADED MAP TILE RENDERER]: Your terrain is corrupted in region {0}, it might take a few minutes to generate the map image depending on the corruption level", m_scene.RegionInfo.RegionName);
                                 terraincorruptedwarningsaid = true;
                             }
                             Color black = Color.Black;
@@ -249,7 +253,7 @@ namespace OpenSim.Region.CoreModules.World.LegacyMap
                 }
             }
 
-            m_log.Debug("[SHADED MAP TILE RENDERER]: Generating Maptile Step 1: Done in " + (Environment.TickCount - tc) + " ms");
+            m_logger?.LogDebug("[SHADED MAP TILE RENDERER]: Generating Maptile Step 1: Done in " + (Environment.TickCount - tc) + " ms");
         }
     }
 }

--- a/Source/OpenSim.Region.CoreModules/World/Media/Moap/MoapModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Media/Moap/MoapModule.cs
@@ -26,25 +26,30 @@
  */
 
 using System.Net;
-using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.Messages.Linden;
+
 using OpenMetaverse.StructuredData;
 using OpenSim.Framework;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 
 using Caps = OpenSim.Framework.Capabilities.Caps;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Media.Moap
 {
     public class MoapModule : INonSharedRegionModule, IMoapModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public string Name { get { return "MoapModule"; } }
         public Type ReplaceableInterface { get { return null; } }
@@ -61,6 +66,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
         public void Initialise(IConfiguration configSource)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MoapModule>>();
             IConfig config = configSource.Configs["MediaOnAPrim"];
 
             if (config != null && !config.GetBoolean("Enabled", false))
@@ -260,7 +266,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 }
                 else
                 {
-                    m_log.ErrorFormat(
+                    m_logger?.LogError(
                         "[MOAP]: ObjectMediaMessage has unrecognized ObjectMediaBlock of {0}",
                         omm.Request.GetType());
                 }
@@ -285,7 +291,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             if (null == part)
             {
-                m_log.WarnFormat(
+                m_logger?.LogWarning(
                     "[MOAP]: Received a GET ObjectMediaRequest for prim {0} but this doesn't exist in region {1}",
                     primId, m_scene.RegionInfo.RegionName);
                 return string.Empty;
@@ -352,7 +358,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             if (null == part)
             {
-                m_log.WarnFormat(
+                m_logger?.LogWarning(
                     "[MOAP]: Received an UPDATE ObjectMediaRequest for prim {0} but this doesn't exist in region {1}",
                     primId, m_scene.RegionInfo.RegionName);
                 return false;
@@ -369,7 +375,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
 
             if (omu.FaceMedia.Length > part.GetNumberOfSides())
             {
-                m_log.WarnFormat(
+                m_logger?.LogWarning(
                     "[MOAP]: Received {0} media entries from client for prim {1} {2} but this prim has only {3} faces.  Dropping request.",
                     omu.FaceMedia.Length, part.Name, part.UUID, part.GetNumberOfSides());
                 return false;
@@ -478,7 +484,7 @@ namespace OpenSim.Region.CoreModules.World.Media.Moap
                 {
                     if (null == part)
                     {
-                        m_log.WarnFormat(
+                        m_logger?.LogWarning(
                             "[MOAP]: Received an ObjectMediaNavigateMessage for prim {0} but this doesn't exist in region {1}",
                             primId, m_scene.RegionInfo.RegionName);
                     }

--- a/Source/OpenSim.Region.CoreModules/World/Objects/BuySell/BuySellModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Objects/BuySell/BuySellModule.cs
@@ -25,22 +25,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenSim.Framework;
+using PermissionMask = OpenSim.Framework.PermissionMask;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Scenes.Serialization;
+using OpenSim.Server.Base;
 
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using Nini.Config;
+
 
 namespace OpenSim.Region.CoreModules.World.Objects.BuySell
 {
     public class BuySellModule : IBuySellModule, INonSharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected Scene m_scene = null;
         protected IDialogModule m_dialogModule;
@@ -48,7 +51,10 @@ namespace OpenSim.Region.CoreModules.World.Objects.BuySell
         public string Name { get { return "Object BuySell Module"; } }
         public Type ReplaceableInterface { get { return null; } }
 
-        public void Initialise(IConfiguration source) {}
+        public void Initialise(IConfiguration source)
+        {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<BuySellModule>>();
+        }
 
         public void AddRegion(Scene scene)
         {

--- a/Source/OpenSim.Region.CoreModules/World/Region/RestartModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Region/RestartModule.cs
@@ -25,23 +25,26 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
 using System.Timers;
-using log4net;
-using Nini.Config;
+using Timer = System.Timers.Timer;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 
-using Timer = System.Timers.Timer;
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Region
 {
     public class RestartModule : INonSharedRegionModule, IRestartModule
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected Scene m_Scene;
         protected Timer m_CountdownTimer = null;
@@ -58,6 +61,7 @@ namespace OpenSim.Region.CoreModules.World.Region
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RestartModule>>();
             IConfig restartConfig = config.Configs["RestartModule"];
             if (restartConfig != null)
             {
@@ -238,7 +242,7 @@ namespace OpenSim.Region.CoreModules.World.Region
             }
             else
             {
-                m_log.WarnFormat(
+                m_logger?.LogWarning(
                     "[RESTART MODULE]: Tried to set restart timer to {0} in {1}, which is not a valid interval",
                     intervalSeconds, m_Scene.Name);
             }
@@ -357,7 +361,7 @@ namespace OpenSim.Region.CoreModules.World.Region
 
         int CountAgents()
         {
-            m_log.Info("[RESTART MODULE]: Counting affected avatars");
+            m_logger?.LogInformation("[RESTART MODULE]: Counting affected avatars");
             int agents = 0;
 
             if (m_rebootAll)
@@ -380,7 +384,7 @@ namespace OpenSim.Region.CoreModules.World.Region
                 }
             }
 
-            m_log.InfoFormat("[RESTART MODULE]: Avatars in region: {0}", agents);
+            m_logger?.LogInformation("[RESTART MODULE]: Avatars in region: {0}", agents);
 
             return agents;
         }

--- a/Source/OpenSim.Region.CoreModules/World/Serialiser/SerialiserModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Serialiser/SerialiserModule.cs
@@ -25,22 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenMetaverse;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Scenes.Serialization;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Serialiser
 {
     public class SerialiserModule : ISharedRegionModule, IRegionSerialiserModule
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
 //        private Commander m_commander = new Commander("export");
         private List<Scene> m_regions = new List<Scene>();
@@ -56,13 +56,14 @@ namespace OpenSim.Region.CoreModules.World.Serialiser
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<SerialiserModule>>();
             IConfig config = source.Configs["Serialiser"];
             if (config != null)
             {
                 m_savedir = config.GetString("save_dir", m_savedir);
             }
 
-            m_log.InfoFormat("[Serialiser] Enabled, using save dir \"{0}\"", m_savedir);
+            m_logger?.LogInformation("[Serialiser] Enabled, using save dir \"{0}\"", m_savedir);
         }
 
         public void PostInitialise()

--- a/Source/OpenSim.Region.CoreModules/World/Terrain/TerrainModifier.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Terrain/TerrainModifier.cs
@@ -24,21 +24,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Reflection;
-using log4net;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.CoreModules.World.Terrain
 {
     public abstract class TerrainModifier : ITerrainModifier
     {
         protected ITerrainModule m_module;
-        protected static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected TerrainModifier(ITerrainModule module)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<TerrainModifier>>();
             m_module = module;
         }
 

--- a/Source/OpenSim.Region.CoreModules/World/Vegetation/VegetationModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Vegetation/VegetationModule.cs
@@ -25,19 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.Vegetation
 {
     public class VegetationModule : INonSharedRegionModule, IVegetationModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected Scene m_scene;
 
@@ -46,6 +50,7 @@ namespace OpenSim.Region.CoreModules.World.Vegetation
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<VegetationModule>>();
         }
 
         public void AddRegion(Scene scene)
@@ -89,7 +94,7 @@ namespace OpenSim.Region.CoreModules.World.Vegetation
         {
             if (Array.IndexOf(creationCapabilities, (PCode)shape.PCode) < 0)
             {
-                m_log.DebugFormat("[VEGETATION]: PCode {0} not handled by {1}", shape.PCode, Name);
+                m_logger?.LogDebug("[VEGETATION]: PCode {0} not handled by {1}", shape.PCode, Name);
                 return null;
             }
 

--- a/Source/OpenSim.Region.CoreModules/World/Warp3DMap/TerrainSplat.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Warp3DMap/TerrainSplat.cs
@@ -25,14 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
-using log4net;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 
 namespace OpenSim.Region.CoreModules.World.Warp3DMap
@@ -66,7 +70,7 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
 
         #endregion Constants
 
-        private static readonly ILog m_log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name);
+        private static ILogger? m_logger;
         private static string LogHeader = "[WARP3D TERRAIN SPLAT]";
 
         /// <summary>
@@ -79,6 +83,10 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
         /// <remarks>Based on the algorithm described at http://opensimulator.org/wiki/Terrain_Splatting
         /// Note we create a 256x256 dimension texture even if the actual terrain is larger.
         /// </remarks>
+
+        static TerrainSplat() {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger>();
+        }
 
         public static Bitmap Splat(ITerrainChannel terrain, UUID[] textureIDs,
                 float[] startHeights, float[] heightRanges,
@@ -135,7 +143,7 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
                             }
                             catch(Exception ex)
                             {
-                                m_log.Warn("Failed to decode cached terrain patch texture" + textureIDs[i] + "): " + ex.Message);
+                                m_logger?.LogWarning("Failed to decode cached terrain patch texture" + textureIDs[i] + "): " + ex.Message);
                             }
                         }
 
@@ -151,7 +159,7 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
                                 }
                                 catch(Exception ex)
                                 {
-                                    m_log.Warn("Failed to decode terrain texture " + asset.ID + ": " + ex.Message);
+                                    m_logger?.LogWarning("Failed to decode terrain texture " + asset.ID + ": " + ex.Message);
                                 }
                             }
 
@@ -243,7 +251,7 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
                     {
                         if(detailTexture[i] == null)
                         {
-                            m_log.DebugFormat("{0} Missing terrain texture for layer {1}. Filling with solid default color", LogHeader, i);
+                            m_logger?.LogDebug("{0} Missing terrain texture for layer {1}. Filling with solid default color", LogHeader, i);
 
                             // Create a solid color texture for this layer
                             detailTexture[i] = new Bitmap(16, 16, PixelFormat.Format24bppRgb);

--- a/Source/OpenSim.Region.CoreModules/World/Wind/Plugins/ConfigurableWind.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Wind/Plugins/ConfigurableWind.cs
@@ -25,18 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-
-using log4net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenMetaverse;
 
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.CoreModules.World.Wind.Plugins
 {
     class ConfigurableWind : IWindModelPlugin
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private Vector2[] m_windSpeeds = new Vector2[16 * 16];
         //private Random m_rndnums = new Random(Environment.TickCount);
@@ -63,7 +63,7 @@ namespace OpenSim.Region.CoreModules.World.Wind.Plugins
 
         public void Initialise()
         {
-
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ConfigurableWind>>();
         }
 
         #endregion
@@ -218,11 +218,11 @@ namespace OpenSim.Region.CoreModules.World.Wind.Plugins
 
         private void LogSettings()
         {
-            m_log.InfoFormat("[ConfigurableWind] Average Strength   : {0}", m_avgStrength);
-            m_log.InfoFormat("[ConfigurableWind] Average Direction  : {0}", m_avgDirection);
-            m_log.InfoFormat("[ConfigurableWind] Varience Strength  : {0}", m_varStrength);
-            m_log.InfoFormat("[ConfigurableWind] Varience Direction : {0}", m_varDirection);
-            m_log.InfoFormat("[ConfigurableWind] Rate Change        : {0}", m_rateChange);
+            m_logger?.LogInformation("[ConfigurableWind] Average Strength   : {0}", m_avgStrength);
+            m_logger?.LogInformation("[ConfigurableWind] Average Direction  : {0}", m_avgDirection);
+            m_logger?.LogInformation("[ConfigurableWind] Varience Strength  : {0}", m_varStrength);
+            m_logger?.LogInformation("[ConfigurableWind] Varience Direction : {0}", m_varDirection);
+            m_logger?.LogInformation("[ConfigurableWind] Rate Change        : {0}", m_rateChange);
         }
 
         #region IWindModelPlugin Members

--- a/Source/OpenSim.Region.CoreModules/World/WorldMap/HGWorldMapModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/WorldMap/HGWorldMapModule.cs
@@ -25,22 +25,26 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+
 using OpenSim.Framework;
 using OpenSim.Region.CoreModules.World.WorldMap;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 
 namespace OpenSim.Region.CoreModules.World.Land
 {
     public class HGWorldMapModule : WorldMapModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         // Remember the map area that each client has been exposed to in this region
         private Dictionary<UUID, List<MapBlockData>> m_SeenMapBlocks = new Dictionary<UUID, List<MapBlockData>>();
@@ -53,6 +57,7 @@ namespace OpenSim.Region.CoreModules.World.Land
 
         public override void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<HGWorldMapModule>>();
             string[] configSections = new string[] { "Map", "Startup" };
             if (Util.GetConfigVarFromSections<string>(
                 source, "WorldMapModule", configSections, "WorldMap") == "HGWorldMap")
@@ -136,7 +141,7 @@ namespace OpenSim.Region.CoreModules.World.Land
                         b.Access = (byte)SimAccess.Down;
                     }
 
-                    m_log.DebugFormat("[HG MAP]: Resetting {0} blocks", mapBlocks.Count);
+                    m_logger?.LogDebug("[HG MAP]: Resetting {0} blocks", mapBlocks.Count);
                     sp.ControllingClient.SendMapBlock(mapBlocks, 0);
                     m_SeenMapBlocks.Remove(clientID);
                 }

--- a/Source/OpenSim.Region.CoreModules/World/WorldMap/MapSearchModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/WorldMap/MapSearchModule.cs
@@ -24,22 +24,25 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
-
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+
+using Nini.Config;
 
 namespace OpenSim.Region.CoreModules.World.WorldMap
 {
     public class MapSearchModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         IGridService m_gridservice = null;
         UUID m_stupidScope = UUID.Zero;
@@ -47,6 +50,7 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
         #region ISharedRegionModule Members
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MapSearchModule>>();
         }
 
         public void AddRegion(Scene scene)

--- a/Source/OpenSim.Region.OptionalModules/Agent/InternetRelayClientView/IRCStackModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/Agent/InternetRelayClientView/IRCStackModule.cs
@@ -26,18 +26,22 @@
  */
 
 using System.Net;
-using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView
 {
     public class IRCStackModule : INonSharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IRCServer m_server;
         private int m_Port;
@@ -48,6 +52,7 @@ namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<IRCStackModule>>();
             if (null != source.Configs["IRCd"] &&
                 source.Configs["IRCd"].GetBoolean("Enabled", false))
             {
@@ -96,9 +101,9 @@ namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView
 
         void user_OnIRCReady(IRCClientView cv)
         {
-            m_log.Info("[IRCd] Adding user...");
+            m_logger?.LogInformation("[IRCd] Adding user...");
             cv.Start();
-            m_log.Info("[IRCd] Added user to Scene");
+            m_logger?.LogInformation("[IRCd] Added user to Scene");
         }
 
     }

--- a/Source/OpenSim.Region.OptionalModules/Agent/InternetRelayClientView/Server/IRCServer.cs
+++ b/Source/OpenSim.Region.OptionalModules/Agent/InternetRelayClientView/Server/IRCServer.cs
@@ -25,17 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using log4net;
-using OpenSim.Framework;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server
 {
@@ -46,6 +44,8 @@ namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server
     /// </summary>
     class IRCServer
     {
+        private static ILogger? m_logger;
+
         public event OnNewIRCUserDelegate OnNewIRCClient;
 
         private readonly TcpListener m_listener;
@@ -54,6 +54,7 @@ namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server
 
         public IRCServer(IPAddress listener, int port, Scene baseScene)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<IRCServer>>();
             m_listener = new TcpListener(listener, port);
 
             m_listener.Start(50);

--- a/Source/OpenSim.Region.OptionalModules/Agent/UDP/Linden/LindenUDPInfoModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/Agent/UDP/Linden/LindenUDPInfoModule.cs
@@ -25,16 +25,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
 using System.Text;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.ClientStack.LindenUDP;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.Agent.UDP.Linden
 {
@@ -46,7 +51,7 @@ namespace OpenSim.Region.OptionalModules.Agent.UDP.Linden
     /// </remarks>
     public class LindenUDPInfoModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected Dictionary<UUID, Scene> m_scenes = new();
 
@@ -56,6 +61,7 @@ namespace OpenSim.Region.OptionalModules.Agent.UDP.Linden
 
         public void Initialise(IConfiguration source)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LindenUDPInfoModule>>();
         }
 
         public void PostInitialise()
@@ -508,12 +514,12 @@ namespace OpenSim.Region.OptionalModules.Agent.UDP.Linden
 
         private void PrintRequests(string type, Dictionary<string, int> sortedDict, int sum)
         {
-            m_log.InfoFormat("[INFO]:");
-            m_log.InfoFormat("[INFO]: {0,25}", type);
+            m_logger?.LogInformation("[INFO]:");
+            m_logger?.LogInformation("[INFO]: {0,25}", type);
             foreach (KeyValuePair<string, int> kvp in sortedDict.Take(12))
-                m_log.InfoFormat("[INFO]: {0,25} {1,-6}", kvp.Key, kvp.Value);
-            m_log.InfoFormat("[INFO]: {0,25}", "...");
-            m_log.InfoFormat("[INFO]: {0,25} {1,-6}", "Total", sum);
+                m_logger?.LogInformation("[INFO]: {0,25} {1,-6}", kvp.Key, kvp.Value);
+            m_logger?.LogInformation("[INFO]: {0,25}", "...");
+            m_logger?.LogInformation("[INFO]: {0,25} {1,-6}", "Total", sum);
         }
     }
 }

--- a/Source/OpenSim.Region.OptionalModules/Avatar/Chat/ChannelState.cs
+++ b/Source/OpenSim.Region.OptionalModules/Avatar/Chat/ChannelState.cs
@@ -25,15 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Text.RegularExpressions;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.Avatar.Chat
 {
@@ -45,8 +45,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
     internal class ChannelState
     {
 
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private static Regex arg = new Regex(@"(?<!\\)\[[^\[\]]*(?<!\\)\]");
         private static int _idk_ = 0;
@@ -109,6 +108,10 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
 
         // Needed by OpenChannel
 
+        static ChannelState() {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ChannelState>>();
+        }
+
         internal ChannelState()
         {
         }
@@ -119,6 +122,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
 
         internal ChannelState(ChannelState model)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ChannelState>>();
             Server = model.Server;
             Password = model.Password;
             IrcChannel = model.IrcChannel;
@@ -158,59 +162,59 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
             // Read in the configuration file and filter everything for variable
             // subsititution.
 
-            m_log.DebugFormat("[IRC-Channel-{0}] Initial request by Region {1} to connect to IRC", cs.idn, rs.Region);
+            m_logger?.LogDebug("[IRC-Channel-{0}] Initial request by Region {1} to connect to IRC", cs.idn, rs.Region);
 
             cs.Server = Substitute(rs, config.GetString("server", null));
-            m_log.DebugFormat("[IRC-Channel-{0}] Server : <{1}>", cs.idn, cs.Server);
+            m_logger?.LogDebug("[IRC-Channel-{0}] Server : <{1}>", cs.idn, cs.Server);
             cs.Password = Substitute(rs, config.GetString("password", null));
             // probably not a good idea to put a password in the log file
             cs.User = Substitute(rs, config.GetString("user", null));
             cs.IrcChannel = Substitute(rs, config.GetString("channel", null));
-            m_log.DebugFormat("[IRC-Channel-{0}] IrcChannel : <{1}>", cs.idn, cs.IrcChannel);
+            m_logger?.LogDebug("[IRC-Channel-{0}] IrcChannel : <{1}>", cs.idn, cs.IrcChannel);
             cs.Port = Convert.ToUInt32(Substitute(rs, config.GetString("port", Convert.ToString(cs.Port))));
-            m_log.DebugFormat("[IRC-Channel-{0}] Port : <{1}>", cs.idn, cs.Port);
+            m_logger?.LogDebug("[IRC-Channel-{0}] Port : <{1}>", cs.idn, cs.Port);
             cs.BaseNickname = Substitute(rs, config.GetString("nick", cs.BaseNickname));
-            m_log.DebugFormat("[IRC-Channel-{0}] BaseNickname : <{1}>", cs.idn, cs.BaseNickname);
+            m_logger?.LogDebug("[IRC-Channel-{0}] BaseNickname : <{1}>", cs.idn, cs.BaseNickname);
             cs.RandomizeNickname = Convert.ToBoolean(Substitute(rs, config.GetString("randomize_nick", Convert.ToString(cs.RandomizeNickname))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RandomizeNickname : <{1}>", cs.idn, cs.RandomizeNickname);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RandomizeNickname : <{1}>", cs.idn, cs.RandomizeNickname);
             cs.RandomizeNickname = Convert.ToBoolean(Substitute(rs, config.GetString("nicknum", Convert.ToString(cs.RandomizeNickname))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RandomizeNickname : <{1}>", cs.idn, cs.RandomizeNickname);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RandomizeNickname : <{1}>", cs.idn, cs.RandomizeNickname);
             cs.User = Substitute(rs, config.GetString("username", cs.User));
-            m_log.DebugFormat("[IRC-Channel-{0}] User : <{1}>", cs.idn, cs.User);
+            m_logger?.LogDebug("[IRC-Channel-{0}] User : <{1}>", cs.idn, cs.User);
             cs.CommandsEnabled = Convert.ToBoolean(Substitute(rs, config.GetString("commands_enabled", Convert.ToString(cs.CommandsEnabled))));
-            m_log.DebugFormat("[IRC-Channel-{0}] CommandsEnabled : <{1}>", cs.idn, cs.CommandsEnabled);
+            m_logger?.LogDebug("[IRC-Channel-{0}] CommandsEnabled : <{1}>", cs.idn, cs.CommandsEnabled);
             cs.CommandChannel = Convert.ToInt32(Substitute(rs, config.GetString("commandchannel", Convert.ToString(cs.CommandChannel))));
-            m_log.DebugFormat("[IRC-Channel-{0}] CommandChannel : <{1}>", cs.idn, cs.CommandChannel);
+            m_logger?.LogDebug("[IRC-Channel-{0}] CommandChannel : <{1}>", cs.idn, cs.CommandChannel);
             cs.CommandChannel = Convert.ToInt32(Substitute(rs, config.GetString("command_channel", Convert.ToString(cs.CommandChannel))));
-            m_log.DebugFormat("[IRC-Channel-{0}] CommandChannel : <{1}>", cs.idn, cs.CommandChannel);
+            m_logger?.LogDebug("[IRC-Channel-{0}] CommandChannel : <{1}>", cs.idn, cs.CommandChannel);
             cs.RelayChat = Convert.ToBoolean(Substitute(rs, config.GetString("relay_chat", Convert.ToString(cs.RelayChat))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayChat           : <{1}>", cs.idn, cs.RelayChat);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayChat           : <{1}>", cs.idn, cs.RelayChat);
             cs.RelayPrivateChannels = Convert.ToBoolean(Substitute(rs, config.GetString("relay_private_channels", Convert.ToString(cs.RelayPrivateChannels))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayPrivateChannels : <{1}>", cs.idn, cs.RelayPrivateChannels);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayPrivateChannels : <{1}>", cs.idn, cs.RelayPrivateChannels);
             cs.RelayPrivateChannels = Convert.ToBoolean(Substitute(rs, config.GetString("useworldcomm", Convert.ToString(cs.RelayPrivateChannels))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayPrivateChannels : <{1}>", cs.idn, cs.RelayPrivateChannels);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayPrivateChannels : <{1}>", cs.idn, cs.RelayPrivateChannels);
             cs.RelayChannelOut = Convert.ToInt32(Substitute(rs, config.GetString("relay_private_channel_out", Convert.ToString(cs.RelayChannelOut))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayChannelOut : <{1}>", cs.idn, cs.RelayChannelOut);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayChannelOut : <{1}>", cs.idn, cs.RelayChannelOut);
             cs.RelayChannel = Convert.ToInt32(Substitute(rs, config.GetString("relay_private_channel_in", Convert.ToString(cs.RelayChannel))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayChannel : <{1}>", cs.idn, cs.RelayChannel);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayChannel : <{1}>", cs.idn, cs.RelayChannel);
             cs.RelayChannel = Convert.ToInt32(Substitute(rs, config.GetString("inchannel", Convert.ToString(cs.RelayChannel))));
-            m_log.DebugFormat("[IRC-Channel-{0}] RelayChannel : <{1}>", cs.idn, cs.RelayChannel);
+            m_logger?.LogDebug("[IRC-Channel-{0}] RelayChannel : <{1}>", cs.idn, cs.RelayChannel);
             cs.PrivateMessageFormat = Substitute(rs, config.GetString("msgformat", cs.PrivateMessageFormat));
-            m_log.DebugFormat("[IRC-Channel-{0}] PrivateMessageFormat : <{1}>", cs.idn, cs.PrivateMessageFormat);
+            m_logger?.LogDebug("[IRC-Channel-{0}] PrivateMessageFormat : <{1}>", cs.idn, cs.PrivateMessageFormat);
             cs.NoticeMessageFormat = Substitute(rs, config.GetString("noticeformat", cs.NoticeMessageFormat));
-            m_log.DebugFormat("[IRC-Channel-{0}] NoticeMessageFormat : <{1}>", cs.idn, cs.NoticeMessageFormat);
+            m_logger?.LogDebug("[IRC-Channel-{0}] NoticeMessageFormat : <{1}>", cs.idn, cs.NoticeMessageFormat);
             cs.ClientReporting = Convert.ToInt32(Substitute(rs, config.GetString("verbosity", cs.ClientReporting ? "1" : "0"))) > 0;
-            m_log.DebugFormat("[IRC-Channel-{0}] ClientReporting : <{1}>", cs.idn, cs.ClientReporting);
+            m_logger?.LogDebug("[IRC-Channel-{0}] ClientReporting : <{1}>", cs.idn, cs.ClientReporting);
             cs.ClientReporting = Convert.ToBoolean(Substitute(rs, config.GetString("report_clients", Convert.ToString(cs.ClientReporting))));
-            m_log.DebugFormat("[IRC-Channel-{0}] ClientReporting : <{1}>", cs.idn, cs.ClientReporting);
+            m_logger?.LogDebug("[IRC-Channel-{0}] ClientReporting : <{1}>", cs.idn, cs.ClientReporting);
             cs.DefaultZone = Substitute(rs, config.GetString("fallback_region", cs.DefaultZone));
-            m_log.DebugFormat("[IRC-Channel-{0}] DefaultZone : <{1}>", cs.idn, cs.DefaultZone);
+            m_logger?.LogDebug("[IRC-Channel-{0}] DefaultZone : <{1}>", cs.idn, cs.DefaultZone);
             cs.ConnectDelay = Convert.ToInt32(Substitute(rs, config.GetString("connect_delay", Convert.ToString(cs.ConnectDelay))));
-            m_log.DebugFormat("[IRC-Channel-{0}] ConnectDelay : <{1}>", cs.idn, cs.ConnectDelay);
+            m_logger?.LogDebug("[IRC-Channel-{0}] ConnectDelay : <{1}>", cs.idn, cs.ConnectDelay);
             cs.PingDelay = Convert.ToInt32(Substitute(rs, config.GetString("ping_delay", Convert.ToString(cs.PingDelay))));
-            m_log.DebugFormat("[IRC-Channel-{0}] PingDelay : <{1}>", cs.idn, cs.PingDelay);
+            m_logger?.LogDebug("[IRC-Channel-{0}] PingDelay : <{1}>", cs.idn, cs.PingDelay);
             cs.AccessPassword = Substitute(rs, config.GetString("access_password", cs.AccessPassword));
-            m_log.DebugFormat("[IRC-Channel-{0}] AccessPassword : <{1}>", cs.idn, cs.AccessPassword);
+            m_logger?.LogDebug("[IRC-Channel-{0}] AccessPassword : <{1}>", cs.idn, cs.AccessPassword);
             string[] excludes = config.GetString("exclude_list", "").Trim().Split(new Char[] { ',' });
             cs.ExcludeList = new List<string>(excludes.Length);
             foreach (string name in excludes)
@@ -229,12 +233,12 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
             else if (cs.User == null)
                 throw new Exception(String.Format("[IRC-Channel-{0}] Invalid configuration for region {1}: user missing", cs.idn, rs.Region));
 
-            m_log.InfoFormat("[IRC-Channel-{0}] Configuration for Region {1} is valid", cs.idn, rs.Region);
-            m_log.InfoFormat("[IRC-Channel-{0}]    Server = {1}", cs.idn, cs.Server);
-            m_log.InfoFormat("[IRC-Channel-{0}]   Channel = {1}", cs.idn, cs.IrcChannel);
-            m_log.InfoFormat("[IRC-Channel-{0}]      Port = {1}", cs.idn, cs.Port);
-            m_log.InfoFormat("[IRC-Channel-{0}]  Nickname = {1}", cs.idn, cs.BaseNickname);
-            m_log.InfoFormat("[IRC-Channel-{0}]      User = {1}", cs.idn, cs.User);
+            m_logger?.LogInformation("[IRC-Channel-{0}] Configuration for Region {1} is valid", cs.idn, rs.Region);
+            m_logger?.LogInformation("[IRC-Channel-{0}]    Server = {1}", cs.idn, cs.Server);
+            m_logger?.LogInformation("[IRC-Channel-{0}]   Channel = {1}", cs.idn, cs.IrcChannel);
+            m_logger?.LogInformation("[IRC-Channel-{0}]      Port = {1}", cs.idn, cs.Port);
+            m_logger?.LogInformation("[IRC-Channel-{0}]  Nickname = {1}", cs.idn, cs.BaseNickname);
+            m_logger?.LogInformation("[IRC-Channel-{0}]      User = {1}", cs.idn, cs.User);
 
             // Set the channel state for this region
 
@@ -280,13 +284,13 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
                 {
                     if (cs.IsAPerfectMatchFor(xcs))
                     {
-                        m_log.DebugFormat("[IRC-Channel-{0}]  Channel state matched", cs.idn);
+                        m_logger?.LogDebug("[IRC-Channel-{0}]  Channel state matched", cs.idn);
                         cs = xcs;
                         break;
                     }
                     if (cs.IsAConnectionMatchFor(xcs))
                     {
-                        m_log.DebugFormat("[IRC-Channel-{0}]  Channel matched", cs.idn);
+                        m_logger?.LogDebug("[IRC-Channel-{0}]  Channel matched", cs.idn);
                         cs.irc = xcs.irc;
                         break;
                     }
@@ -299,14 +303,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
             if (cs.irc == null)
             {
 
-                m_log.DebugFormat("[IRC-Channel-{0}]  New channel required", cs.idn);
+                m_logger?.LogDebug("[IRC-Channel-{0}]  New channel required", cs.idn);
 
                 if ((cs.irc = new IRCConnector(cs)) != null)
                 {
 
                     IRCBridgeModule.m_channels.Add(cs);
 
-                    m_log.InfoFormat("[IRC-Channel-{0}] New channel initialized for {1}, nick: {2}, commands {3}, private channels {4}",
+                    m_logger?.LogInformation("[IRC-Channel-{0}] New channel initialized for {1}, nick: {2}, commands {3}, private channels {4}",
                                  cs.idn, rs.Region, cs.DefaultZone,
                                  cs.CommandsEnabled ? "enabled" : "not enabled",
                                  cs.RelayPrivateChannels ? "relayed" : "not relayed");
@@ -315,17 +319,17 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
                 {
                     string txt = String.Format("[IRC-Channel-{0}] Region {1} failed to connect to channel {2} on server {3}:{4}",
                             cs.idn, rs.Region, cs.IrcChannel, cs.Server, cs.Port);
-                    m_log.Error(txt);
+                    m_logger?.LogError(txt);
                     throw new Exception(txt);
                 }
             }
             else
             {
-                m_log.InfoFormat("[IRC-Channel-{0}] Region {1} reusing existing connection to channel {2} on server {3}:{4}",
+                m_logger?.LogInformation("[IRC-Channel-{0}] Region {1} reusing existing connection to channel {2} on server {3}:{4}",
                         cs.idn, rs.Region, cs.IrcChannel, cs.Server, cs.Port);
             }
 
-            m_log.InfoFormat("[IRC-Channel-{0}] Region {1} associated with channel {2} on server {3}:{4}",
+            m_logger?.LogInformation("[IRC-Channel-{0}] Region {1} associated with channel {2} on server {3}:{4}",
                         cs.idn, rs.Region, cs.IrcChannel, cs.Server, cs.Port);
 
             // We're finally ready to commit ourselves
@@ -467,7 +471,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
             // Repeatedly scan the string until all possible
             // substitutions have been performed.
 
-            // m_log.DebugFormat("[IRC-Channel] Parse[1]: {0}", result);
+            // m_logger?.LogDebug("[IRC-Channel] Parse[1]: {0}", result);
 
             while (arg.IsMatch(result))
             {
@@ -496,29 +500,29 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
                         result = result.Replace(vvar, rs.config.GetString(var, var));
                         break;
                 }
-                // m_log.DebugFormat("[IRC-Channel] Parse[2]: {0}", result);
+                // m_logger?.LogDebug("[IRC-Channel] Parse[2]: {0}", result);
             }
 
             // Now we unescape the literal brackets
             result = result.Replace(@"\[","[").Replace(@"\]","]");
 
-            // m_log.DebugFormat("[IRC-Channel] Parse[3]: {0}", result);
+            // m_logger?.LogDebug("[IRC-Channel] Parse[3]: {0}", result);
             return result;
 
         }
 
         public void Close()
         {
-            m_log.InfoFormat("[IRC-Channel-{0}] Closing channel <{1}> to server <{2}:{3}>",
+            m_logger?.LogInformation("[IRC-Channel-{0}] Closing channel <{1}> to server <{2}:{3}>",
                              idn, IrcChannel, Server, Port);
-            m_log.InfoFormat("[IRC-Channel-{0}] There are {1} active clients",
+            m_logger?.LogInformation("[IRC-Channel-{0}] There are {1} active clients",
                              idn, clientregions.Count);
             irc.Close();
         }
 
         public void Open()
         {
-            m_log.InfoFormat("[IRC-Channel-{0}] Opening channel <{1}> to server <{2}:{3}>",
+            m_logger?.LogInformation("[IRC-Channel-{0}] Opening channel <{1}> to server <{2}:{3}>",
                              idn, IrcChannel, Server, Port);
 
             irc.Open();
@@ -547,9 +551,9 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
                 {
                     Close();
                     IRCBridgeModule.m_channels.Remove(this);
-                    m_log.InfoFormat("[IRC-Channel-{0}] Region {1} is last user of channel <{2}> to server <{3}:{4}>",
+                    m_logger?.LogInformation("[IRC-Channel-{0}] Region {1} is last user of channel <{2}> to server <{3}:{4}>",
                              idn, rs.Region, IrcChannel, Server, Port);
-                    m_log.InfoFormat("[IRC-Channel-{0}] Removed", idn);
+                    m_logger?.LogInformation("[IRC-Channel-{0}] Removed", idn);
                 }
             }
         }
@@ -558,7 +562,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
 
         public void AddRegion(RegionState rs)
         {
-            m_log.InfoFormat("[IRC-Channel-{0}] Adding region {1} to channel <{2}> to server <{3}:{4}>",
+            m_logger?.LogInformation("[IRC-Channel-{0}] Adding region {1} to channel <{2}> to server <{3}:{4}>",
                              idn, rs.Region, IrcChannel, Server, Port);
             if (!clientregions.Contains(rs))
             {
@@ -574,7 +578,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
         public void RemoveRegion(RegionState rs)
         {
 
-            m_log.InfoFormat("[IRC-Channel-{0}] Removing region {1} from channel <{2} to server <{3}:{4}>",
+            m_logger?.LogInformation("[IRC-Channel-{0}] Removing region {1} from channel <{2} to server <{3}:{4}>",
                              idn, rs.Region, IrcChannel, Server, Port);
 
             if (clientregions.Contains(rs))
@@ -592,7 +596,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
         public static void OSChat(IRCConnector p_irc, OSChatMessage c, bool cmsg)
         {
 
-            // m_log.DebugFormat("[IRC-OSCHAT] from {0}:{1}", p_irc.Server, p_irc.IrcChannel);
+            // m_logger?.LogDebug("[IRC-OSCHAT] from {0}:{1}", p_irc.Server, p_irc.IrcChannel);
 
             try
             {
@@ -630,8 +634,8 @@ namespace OpenSim.Region.OptionalModules.Avatar.Chat
             }
             catch (Exception ex)
             {
-                m_log.ErrorFormat("[IRC-OSCHAT]: BroadcastSim Exception: {0}", ex.Message);
-                m_log.Debug(ex);
+                m_logger?.LogError("[IRC-OSCHAT]: BroadcastSim Exception: {0}", ex.Message);
+                m_logger?.LogDebug("{0}", ex);
             }
         }
     }

--- a/Source/OpenSim.Region.OptionalModules/Avatar/Concierge/ConciergeModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/Avatar/Concierge/ConciergeModule.cs
@@ -27,24 +27,30 @@
 
 using System.Collections;
 using System.Net;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using log4net;
-using Nini.Config;
-using Nwc.XmlRpc;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.CoreModules.Avatar.Chat;
+using OpenSim.Server.Base;
+
+using Nwc.XmlRpc;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.Avatar.Concierge
 {
     public class ConciergeModule : ChatModule, ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
 //        private const int DEBUG_CHANNEL = 2147483647; use base value
 
@@ -70,6 +76,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
         #region ISharedRegionModule Members
         public override void Initialise(IConfiguration configSource)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<ConciergeModule>>();
             IConfig config = configSource.Configs["Concierge"];
 
             if (config == null)
@@ -101,7 +108,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                 m_replacingChatModule = false;
             }
 
-            m_log.InfoFormat("[Concierge] {0} ChatModule", m_replacingChatModule ? "replacing" : "not replacing");
+            m_logger?.LogInformation("[Concierge] {0} ChatModule", m_replacingChatModule ? "replacing" : "not replacing");
 
             // take note of concierge channel and of identity
             m_conciergeChannel = configSource.Configs["Concierge"].GetInt("concierge_channel", m_conciergeChannel);
@@ -113,7 +120,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             m_brokerURI = config.GetString("broker", m_brokerURI);
             m_brokerUpdateTimeout = config.GetInt("broker_timeout", m_brokerUpdateTimeout);
 
-            m_log.InfoFormat("[Concierge] reporting as \"{0}\" to our users", m_whoami);
+            m_logger?.LogInformation("[Concierge] reporting as \"{0}\" to our users", m_whoami);
 
             // calculate regions Regex
             if (m_regions == null)
@@ -155,7 +162,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                     scene.EventManager.OnMakeChildAgent += OnMakeChildAgent;
                 }
             }
-            m_log.InfoFormat("[Concierge]: initialized for {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[Concierge]: initialized for {0}", scene.RegionInfo.RegionName);
         }
 
         public override void RemoveRegion(Scene scene)
@@ -189,7 +196,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                     m_conciergedScenes.Remove(scene);
                 }
             }
-            m_log.InfoFormat("[Concierge]: removed {0}", scene.RegionInfo.RegionName);
+            m_logger?.LogInformation("[Concierge]: removed {0}", scene.RegionInfo.RegionName);
         }
 
         public override void PostInitialise()
@@ -301,7 +308,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             if (m_conciergedScenes.Contains(client.Scene))
             {
                 Scene scene = client.Scene as Scene;
-                m_log.DebugFormat("[Concierge]: {0} logs off from {1}", client.Name, scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[Concierge]: {0} logs off from {1}", client.Name, scene.RegionInfo.RegionName);
                 AnnounceToAgentsRegion(scene, String.Format(m_announceLeaving, client.Name, scene.RegionInfo.RegionName, scene.GetRootAgentCount()));
                 UpdateBroker(scene);
             }
@@ -313,7 +320,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             if (m_conciergedScenes.Contains(agent.Scene))
             {
                 Scene scene = agent.Scene;
-                m_log.DebugFormat("[Concierge]: {0} enters {1}", agent.Name, scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[Concierge]: {0} enters {1}", agent.Name, scene.RegionInfo.RegionName);
                 WelcomeAvatar(agent, scene);
                 AnnounceToAgentsRegion(scene, String.Format(m_announceEntering, agent.Name,
                                                             scene.RegionInfo.RegionName, scene.GetRootAgentCount()));
@@ -327,7 +334,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             if (m_conciergedScenes.Contains(agent.Scene))
             {
                 Scene scene = agent.Scene;
-                m_log.DebugFormat("[Concierge]: {0} leaves {1}", agent.Name, scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[Concierge]: {0} leaves {1}", agent.Name, scene.RegionInfo.RegionName);
                 AnnounceToAgentsRegion(scene, String.Format(m_announceLeaving, agent.Name,
                                                             scene.RegionInfo.RegionName, scene.GetRootAgentCount()));
                 UpdateBroker(scene);
@@ -385,17 +392,17 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                                      BrokerState b = state as BrokerState;
                                      b.Poster.Abort();
                                      b.Timer.Dispose();
-                                     m_log.Debug("[Concierge]: async broker POST abort due to timeout");
+                                     m_logger?.LogDebug("[Concierge]: async broker POST abort due to timeout");
                                  }, bs, m_brokerUpdateTimeout * 1000, Timeout.Infinite);
 
             try
             {
                 updatePost.BeginGetRequestStream(UpdateBrokerSend, bs);
-                m_log.DebugFormat("[Concierge] async broker POST to {0} started", uri);
+                m_logger?.LogDebug("[Concierge] async broker POST to {0} started", uri);
             }
             catch (WebException we)
             {
-                m_log.ErrorFormat("[Concierge] async broker POST to {0} failed: {1}", uri, we.Status);
+                m_logger?.LogError("[Concierge] async broker POST to {0} failed: {1}", uri, we.Status);
             }
         }
 
@@ -417,11 +424,11 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             }
             catch (WebException we)
             {
-                m_log.DebugFormat("[Concierge]: async broker POST to {0} failed: {1}", bs.Uri, we.Status);
+                m_logger?.LogDebug("[Concierge]: async broker POST to {0} failed: {1}", bs.Uri, we.Status);
             }
             catch (Exception)
             {
-                m_log.DebugFormat("[Concierge]: async broker POST to {0} failed", bs.Uri);
+                m_logger?.LogDebug("[Concierge]: async broker POST to {0} failed", bs.Uri);
             }
         }
 
@@ -434,25 +441,25 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                 HttpWebRequest updatePost = bs.Poster;
                 using (HttpWebResponse response = updatePost.EndGetResponse(result) as HttpWebResponse)
                 {
-                    m_log.DebugFormat("[Concierge] broker update: status {0}", response.StatusCode);
+                    m_logger?.LogDebug("[Concierge] broker update: status {0}", response.StatusCode);
                 }
                 bs.Timer.Dispose();
             }
             catch (WebException we)
             {
-                m_log.ErrorFormat("[Concierge] broker update to {0} failed with status {1}", bs.Uri, we.Status);
+                m_logger?.LogError("[Concierge] broker update to {0} failed with status {1}", bs.Uri, we.Status);
                 if (null != we.Response)
                 {
                     using (HttpWebResponse resp = we.Response as HttpWebResponse)
                     {
-                        m_log.ErrorFormat("[Concierge] response from {0} status code: {1}", bs.Uri, resp.StatusCode);
-                        m_log.ErrorFormat("[Concierge] response from {0} status desc: {1}", bs.Uri, resp.StatusDescription);
-                        m_log.ErrorFormat("[Concierge] response from {0} server:      {1}", bs.Uri, resp.Server);
+                        m_logger?.LogError("[Concierge] response from {0} status code: {1}", bs.Uri, resp.StatusCode);
+                        m_logger?.LogError("[Concierge] response from {0} status desc: {1}", bs.Uri, resp.StatusDescription);
+                        m_logger?.LogError("[Concierge] response from {0} server:      {1}", bs.Uri, resp.Server);
 
                         if (resp.ContentLength > 0)
                         {
                             using(StreamReader content = new StreamReader(resp.GetResponseStream()))
-                                m_log.ErrorFormat("[Concierge] response from {0} content:     {1}", bs.Uri, content.ReadToEnd());
+                                m_logger?.LogError("[Concierge] response from {0} content:     {1}", bs.Uri, content.ReadToEnd());
                         }
                     }
                 }
@@ -483,17 +490,17 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                         }
                         catch (IOException ioe)
                         {
-                            m_log.ErrorFormat("[Concierge]: run into trouble reading welcome file {0} for region {1} for avatar {2}: {3}",
+                            m_logger?.LogError("[Concierge]: run into trouble reading welcome file {0} for region {1} for avatar {2}: {3}",
                                              welcome, scene.RegionInfo.RegionName, agent.Name, ioe);
                         }
                         catch (FormatException fe)
                         {
-                            m_log.ErrorFormat("[Concierge]: welcome file {0} is malformed: {1}", welcome, fe);
+                            m_logger?.LogError("[Concierge]: welcome file {0} is malformed: {1}", welcome, fe);
                         }
                     }
                     return;
                 }
-                m_log.DebugFormat("[Concierge]: no welcome message for region {0}", scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[Concierge]: no welcome message for region {0}", scene.RegionInfo.RegionName);
             }
         }
 
@@ -505,7 +512,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
         //     if ((client.Scene is Scene) && (client.Scene as Scene).TryGetScenePresence(client.AgentId, out agent))
         //         AnnounceToAgentsRegion(agent, msg);
         //     else
-        //         m_log.DebugFormat("[Concierge]: could not find an agent for client {0}", client.Name);
+        //         m_logger?.LogDebug("[Concierge]: could not find an agent for client {0}", client.Name);
         // }
 
         protected void AnnounceToAgentsRegion(IScene scene, string msg)
@@ -556,7 +563,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
 
         public XmlRpcResponse XmlRpcUpdateWelcomeMethod(XmlRpcRequest request, IPEndPoint remoteClient)
         {
-            m_log.Info("[Concierge]: processing UpdateWelcome request");
+            m_logger?.LogInformation("[Concierge]: processing UpdateWelcome request");
             XmlRpcResponse response = new XmlRpcResponse();
             Hashtable responseData = new Hashtable();
 
@@ -587,7 +594,7 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
                 string welcome = Path.Combine(m_welcomes, regionName);
                 if (File.Exists(welcome))
                 {
-                    m_log.InfoFormat("[Concierge]: UpdateWelcome: updating existing template \"{0}\"", welcome);
+                    m_logger?.LogInformation("[Concierge]: UpdateWelcome: updating existing template \"{0}\"", welcome);
                     string welcomeBackup = String.Format("{0}~", welcome);
                     if (File.Exists(welcomeBackup))
                         File.Delete(welcomeBackup);
@@ -600,14 +607,14 @@ namespace OpenSim.Region.OptionalModules.Avatar.Concierge
             }
             catch (Exception e)
             {
-                m_log.InfoFormat("[Concierge]: UpdateWelcome failed: {0}", e.Message);
+                m_logger?.LogInformation("[Concierge]: UpdateWelcome failed: {0}", e.Message);
 
                 responseData["success"] = "false";
                 responseData["error"] = e.Message;
 
                 response.Value = responseData;
             }
-            m_log.Debug("[Concierge]: done processing UpdateWelcome request");
+            m_logger?.LogDebug("[Concierge]: done processing UpdateWelcome request");
             return response;
         }
     }

--- a/Source/OpenSim.Region.OptionalModules/DataSnapshot/Providers/LandSnapshot.cs
+++ b/Source/OpenSim.Region.OptionalModules/DataSnapshot/Providers/LandSnapshot.cs
@@ -25,18 +25,19 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Xml;
-using log4net;
-using OpenMetaverse;
-using OpenSim.Framework;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using OpenMetaverse;
+
+using OpenSim.Framework;
 using OpenSim.Region.CoreModules.World.Land;
 using OpenSim.Region.OptionalModules.DataSnapshot.Interfaces;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 
 namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
@@ -46,7 +47,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
         private Scene m_scene = null;
         private DataSnapshotManager m_parent = null;
         //private Dictionary<int, Land> m_landIndexed = new Dictionary<int, Land>();
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private bool m_stale = true;
 
         #region Dead code
@@ -106,6 +107,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
 
         public void Initialize(Scene scene, DataSnapshotManager parent)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LandSnapshot>>();
             m_scene = scene;
             m_parent = parent;
 
@@ -404,7 +406,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
         // another, smaller rectangular parcel). Both will have the same initial coordinates.
         private void findPointInParcel(ILandObject land, ref uint refX, ref uint refY)
         {
-            m_log.DebugFormat("[DATASNAPSHOT] trying {0}, {1}", refX, refY);
+            m_logger?.LogDebug("[DATASNAPSHOT] trying {0}, {1}", refX, refY);
             // the point we started with already is in the parcel
             if (land.ContainsPoint((int)refX, (int)refY)) return;
 

--- a/Source/OpenSim.Region.OptionalModules/DataSnapshot/Providers/ObjectSnapshot.cs
+++ b/Source/OpenSim.Region.OptionalModules/DataSnapshot/Providers/ObjectSnapshot.cs
@@ -25,16 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Xml;
-using log4net;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.OptionalModules.DataSnapshot.Interfaces;
-using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
 {
@@ -42,7 +43,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
     {
         private Scene m_scene = null;
         // private DataSnapshotManager m_parent = null;
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private bool m_stale = true;
 
         private static UUID m_DefaultImage = new UUID("89556747-24cb-43ed-920b-47caed15465f");
@@ -51,6 +52,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
 
         public void Initialize(Scene scene, DataSnapshotManager parent)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<RemoteMuteListServicesConnector>>();
             m_scene = scene;
             // m_parent = parent;
 
@@ -97,7 +99,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
 
         public XmlNode RequestSnapshotData(XmlDocument nodeFactory)
         {
-            m_log.Debug("[DATASNAPSHOT]: Generating object data for scene " + m_scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[DATASNAPSHOT]: Generating object data for scene " + m_scene.RegionInfo.RegionName);
 
             XmlNode parent = nodeFactory.CreateNode(XmlNodeType.Element, "objectdata", "");
             XmlNode node;
@@ -110,7 +112,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
                 {
                     SceneObjectGroup obj = (SceneObjectGroup)entity;
 
-//                    m_log.Debug("[DATASNAPSHOT]: Found object " + obj.Name + " in scene");
+//                    m_logger?.LogDebug("[DATASNAPSHOT]: Found object " + obj.Name + " in scene");
 
                     // libomv will complain about PrimFlags.JointWheel
                     // being obsolete, so we...
@@ -151,7 +153,7 @@ namespace OpenSim.Region.OptionalModules.DataSnapshot.Providers
                         else
                         {
                             // Something is wrong with this object. Let's not list it.
-                            m_log.WarnFormat("[DATASNAPSHOT]: Bad data for object {0} ({1}) in region {2}", obj.Name, obj.UUID, m_scene.RegionInfo.RegionName);
+                            m_logger?.LogWarning("[DATASNAPSHOT]: Bad data for object {0} ({1}) in region {2}", obj.Name, obj.UUID, m_scene.RegionInfo.RegionName);
                             continue;
                         }
 

--- a/Source/OpenSim.Region.OptionalModules/Example/BareBonesNonShared/BareBonesNonSharedModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/Example/BareBonesNonShared/BareBonesNonSharedModule.cs
@@ -25,11 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 // You will need to uncomment these lines if you are adding a region module to some other assembly which does not already
 // specify its assembly.  Otherwise, the region modules in the assembly will not be picked up when OpenSimulator scans
@@ -55,7 +58,7 @@ namespace OpenSim.Region.OptionalModules.Example.BareBonesNonShared
     /// </remarks>
     public class BareBonesNonSharedModule : INonSharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public string Name { get { return "Bare Bones Non Shared Module"; } }
 
@@ -63,27 +66,28 @@ namespace OpenSim.Region.OptionalModules.Example.BareBonesNonShared
 
         public void Initialise(IConfiguration source)
         {
-            m_log.DebugFormat("[BARE BONES NON SHARED]: INITIALIZED MODULE");
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<BareBonesNonSharedModule>>();
+            m_logger?.LogDebug("[BARE BONES NON SHARED]: INITIALIZED MODULE");
         }
 
         public void Close()
         {
-            m_log.DebugFormat("[BARE BONES NON SHARED]: CLOSED MODULE");
+            m_logger?.LogDebug("[BARE BONES NON SHARED]: CLOSED MODULE");
         }
 
         public void AddRegion(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES NON SHARED]: REGION {0} ADDED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES NON SHARED]: REGION {0} ADDED", scene.RegionInfo.RegionName);
         }
 
         public void RemoveRegion(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES NON SHARED]: REGION {0} REMOVED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES NON SHARED]: REGION {0} REMOVED", scene.RegionInfo.RegionName);
         }
 
         public void RegionLoaded(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES NON SHARED]: REGION {0} LOADED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES NON SHARED]: REGION {0} LOADED", scene.RegionInfo.RegionName);
         }
     }
 }

--- a/Source/OpenSim.Region.OptionalModules/Example/BareBonesShared/BareBonesSharedModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/Example/BareBonesShared/BareBonesSharedModule.cs
@@ -25,11 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 // You will need to uncomment these lines if you are adding a region module to some other assembly which does not already
 // specify its assembly.  Otherwise, the region modules in the assembly will not be picked up when OpenSimulator scans
@@ -55,7 +58,7 @@ namespace OpenSim.Region.OptionalModules.Example.BareBonesShared
     /// </remarks>
     public class BareBonesSharedModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public string Name { get { return "Bare Bones Shared Module"; } }
 
@@ -63,32 +66,33 @@ namespace OpenSim.Region.OptionalModules.Example.BareBonesShared
 
         public void Initialise(IConfiguration source)
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: INITIALIZED MODULE");
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<BareBonesSharedModule>>();
+            m_logger?.LogDebug("[BARE BONES SHARED]: INITIALIZED MODULE");
         }
 
         public void PostInitialise()
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: POST INITIALIZED MODULE");
+            m_logger?.LogDebug("[BARE BONES SHARED]: POST INITIALIZED MODULE");
         }
 
         public void Close()
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: CLOSED MODULE");
+            m_logger?.LogDebug("[BARE BONES SHARED]: CLOSED MODULE");
         }
 
         public void AddRegion(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: REGION {0} ADDED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES SHARED]: REGION {0} ADDED", scene.RegionInfo.RegionName);
         }
 
         public void RemoveRegion(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: REGION {0} REMOVED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES SHARED]: REGION {0} REMOVED", scene.RegionInfo.RegionName);
         }
 
         public void RegionLoaded(Scene scene)
         {
-            m_log.DebugFormat("[BARE BONES SHARED]: REGION {0} LOADED", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[BARE BONES SHARED]: REGION {0} LOADED", scene.RegionInfo.RegionName);
         }
     }
 }

--- a/Source/OpenSim.Region.OptionalModules/PrimLimitsModule/PrimLimitsModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/PrimLimitsModule/PrimLimitsModule.cs
@@ -25,13 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.PrimLimitsModule
 {
@@ -44,7 +48,7 @@ namespace OpenSim.Region.OptionalModules.PrimLimitsModule
     public class PrimLimitsModule : INonSharedRegionModule
     {
         protected IDialogModule m_dialogModule;
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private bool m_enabled;
 
         private Scene m_scene;
@@ -54,6 +58,7 @@ namespace OpenSim.Region.OptionalModules.PrimLimitsModule
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<PrimLimitsModule>>();
             string permissionModules = Util.GetConfigVarFromSections<string>(config, "permissionmodules",
                 new string[] { "Startup", "Permissions" }, "DefaultPermissionsModule");
 
@@ -62,7 +67,7 @@ namespace OpenSim.Region.OptionalModules.PrimLimitsModule
             if(!modules.Contains("PrimLimitsModule"))
                 return;
 
-            m_log.DebugFormat("[PRIM LIMITS]: Initialized module");
+            m_logger?.LogDebug("[PRIM LIMITS]: Initialized module");
             m_enabled = true;
         }
 
@@ -81,7 +86,7 @@ namespace OpenSim.Region.OptionalModules.PrimLimitsModule
             scene.Permissions.OnObjectEnterWithScripts += CanObjectEnterWithScripts;
             scene.Permissions.OnDuplicateObject += CanDuplicateObject;
 
-            m_log.DebugFormat("[PRIM LIMITS]: Region {0} added", scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[PRIM LIMITS]: Region {0} added", scene.RegionInfo.RegionName);
         }
 
         public void RemoveRegion(Scene scene)

--- a/Source/OpenSim.Region.OptionalModules/Scripting/JsonStore/JsonStore.cs
+++ b/Source/OpenSim.Region.OptionalModules/Scripting/JsonStore/JsonStore.cs
@@ -25,19 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 using System.Reflection;
-using log4net;
+using System.Text.RegularExpressions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using System.Text.RegularExpressions;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
 {
     public class JsonStore
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected virtual OSD ValueStore { get; set; }
 
@@ -114,6 +118,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
         // -----------------------------------------------------------------
         public JsonStore()
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<JsonStore>>();
             StringSpace = 0;
             m_TakeStore = new List<TakeValueCallbackClass>();
             m_ReadStore = new List<TakeValueCallbackClass>();
@@ -467,7 +472,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
             }
 
             // Shouldn't get here if the path was checked correctly
-            m_log.WarnFormat("[JsonStore] invalid path expression");
+            m_logger?.LogWarning("[JsonStore] invalid path expression");
             return false;
         }
 
@@ -562,7 +567,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
             {
                 if (rmap.Type != OSDType.Array)
                 {
-                    m_log.WarnFormat("[JsonStore] wrong type for key {2}, expecting {0}, got {1}",OSDType.Array,rmap.Type,pkey);
+                    m_logger?.LogWarning("[JsonStore] wrong type for key {2}, expecting {0}, got {1}",OSDType.Array,rmap.Type,pkey);
                     return null;
                 }
 
@@ -586,7 +591,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
             {
                 if (rmap.Type != OSDType.Map)
                 {
-                    m_log.WarnFormat("[JsonStore] wrong type for key {2}, expecting {0}, got {1}",OSDType.Map,rmap.Type,pkey);
+                    m_logger?.LogWarning("[JsonStore] wrong type for key {2}, expecting {0}, got {1}",OSDType.Map,rmap.Type,pkey);
                     return null;
                 }
 
@@ -603,7 +608,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
             }
 
             // Shouldn't get here if the path was checked correctly
-            m_log.WarnFormat("[JsonStore] Path type (unknown) does not match the structure");
+            m_logger?.LogWarning("[JsonStore] Path type (unknown) does not match the structure");
             return null;
         }
 

--- a/Source/OpenSim.Region.OptionalModules/Scripting/JsonStore/JsonStoreCommands.cs
+++ b/Source/OpenSim.Region.OptionalModules/Scripting/JsonStore/JsonStoreCommands.cs
@@ -24,19 +24,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
 {
     public class JsonStoreCommandsModule  : INonSharedRegionModule
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private IConfig m_config = null;
         private bool m_enabled = false;
@@ -66,6 +68,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
         // -----------------------------------------------------------------
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<JsonStoreCommandsModule>>();
             try
             {
                 if ((m_config = config.Configs["JsonStore"]) == null)
@@ -79,12 +82,12 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
             }
             catch (Exception e)
             {
-                m_log.Error("[JsonStore]: initialization error: {0}", e);
+                m_logger?.LogError("[JsonStore]: initialization error: {0}", e);
                 return;
             }
 
             if (m_enabled)
-                m_log.DebugFormat("[JsonStore]: module is enabled");
+                m_logger?.LogDebug("[JsonStore]: module is enabled");
         }
 
         // -----------------------------------------------------------------
@@ -143,7 +146,7 @@ namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
                 m_store = (JsonStoreModule) m_scene.RequestModuleInterface<IJsonStoreModule>();
                 if (m_store == null)
                 {
-                    m_log.ErrorFormat("[JsonStoreCommands]: JsonModule interface not defined");
+                    m_logger?.LogError("[JsonStoreCommands]: JsonModule interface not defined");
                     m_enabled = false;
                     return;
                 }

--- a/Source/OpenSim.Region.OptionalModules/ServiceConnectorsIn/Freeswitch/FreeswitchServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/ServiceConnectorsIn/Freeswitch/FreeswitchServiceInConnectorModule.cs
@@ -25,24 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Reflection;
-using System.Collections.Generic;
-using log4net;
-using Nini.Config;
-using OpenSim.Framework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenSim.Framework.Servers;
-using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Server.Base;
 using OpenSim.Server.Handlers.Base;
 
+using Nini.Config;
+
 namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Freeswitch
 {
     public class FreeswitchServiceInConnectorModule : ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private static bool m_Enabled = false;
 
         private IConfiguration m_Config;
@@ -52,6 +50,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Freeswitch
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<FreeswitchServiceInConnectorModule>>();
             m_Config = config;
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig != null)
@@ -59,7 +58,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Freeswitch
                 m_Enabled = moduleConfig.GetBoolean("FreeswitchServiceInConnector", false);
                 if (m_Enabled)
                 {
-                    m_log.Info("[FREESWITCH IN CONNECTOR]: FreeswitchServiceInConnector enabled");
+                    m_logger?.LogInformation("[FREESWITCH IN CONNECTOR]: FreeswitchServiceInConnector enabled");
                 }
 
             }
@@ -92,7 +91,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsIn.Freeswitch
             {
                 m_Registered = true;
 
-                m_log.Info("[RegionFreeswitchService]: Starting...");
+                m_logger?.LogInformation("[RegionFreeswitchService]: Starting...");
 
                 Object[] args = new Object[] { m_Config, MainServer.Instance };
 

--- a/Source/OpenSim.Region.OptionalModules/UserStatistics/WebStatsModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/UserStatistics/WebStatsModule.cs
@@ -26,29 +26,32 @@
  */
 
 using System.Collections;
-using System.Reflection;
+using System.Data.SQLite;
 using System.Text;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+using OSD = OpenMetaverse.StructuredData.OSD;
+using OSDMap = OpenMetaverse.StructuredData.OSDMap;
+
 using OpenSim.Framework;
+using Caps = OpenSim.Framework.Capabilities.Caps;
 using OpenSim.Framework.Servers;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using System.Data.SQLite;
+using OpenSim.Server.Base;
 
-using Caps = OpenSim.Framework.Capabilities.Caps;
-using OSD = OpenMetaverse.StructuredData.OSD;
-using OSDMap = OpenMetaverse.StructuredData.OSDMap;
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.UserStatistics
 {
     public class WebStatsModule : ISharedRegionModule
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private static SQLiteConnection dbConn;
 
@@ -72,6 +75,7 @@ namespace OpenSim.Region.OptionalModules.UserStatistics
 
         public virtual void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<WebStatsModule>>();
             IConfig cnfg = config.Configs["WebStats"];
 
             if (cnfg != null)
@@ -473,7 +477,7 @@ namespace OpenSim.Region.OptionalModules.UserStatistics
                 {
                     if (!m_sessions.ContainsKey(agentID))
                     {
-                        m_log.WarnFormat("[WEB STATS MODULE]: no session for stat disclosure for agent {0}", agentID);
+                        m_logger?.LogWarning("[WEB STATS MODULE]: no session for stat disclosure for agent {0}", agentID);
                         return new UserSession();
                     }
 

--- a/Source/OpenSim.Region.OptionalModules/ViewerSupport/DynamicFloaterModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/ViewerSupport/DynamicFloaterModule.cs
@@ -25,19 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
+using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Framework;
+using OpenSim.Server.Base;
+
 using Nini.Config;
-using log4net;
 
 namespace OpenSim.Region.OptionalModules.ViewerSupport
 {
     public class DynamicFloaterModule : INonSharedRegionModule, IDynamicFloaterModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private Scene m_scene;
 
@@ -55,6 +59,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DynamicFloaterModule>>();
         }
 
         public void Close()

--- a/Source/OpenSim.Region.OptionalModules/ViewerSupport/DynamicMenuModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/ViewerSupport/DynamicMenuModule.cs
@@ -26,24 +26,28 @@
  */
 
 using System.Net;
-using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+using OSDMap = OpenMetaverse.StructuredData.OSDMap;
+
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Framework;
-using OpenSim.Framework.Servers.HttpServer;
-using Nini.Config;
-using log4net;
-
 using Caps = OpenSim.Framework.Capabilities.Caps;
-using OSDMap = OpenMetaverse.StructuredData.OSDMap;
+using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.ViewerSupport
 {
     public class DynamicMenuModule : INonSharedRegionModule, IDynamicMenuModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private class MenuItemData
         {
@@ -71,6 +75,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<DynamicMenuModule>>();
         }
 
         public void Close()
@@ -257,8 +262,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
     public class MenuActionHandler : SimpleOSDMapHandler
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private UUID m_agentID;
         private Scene m_scene;
@@ -267,6 +271,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
         public MenuActionHandler(string path, string name, UUID agentID, DynamicMenuModule module, Scene scene)
                 :base("POST", path)
         {
+            // m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MenuActionHandler>>();
             m_agentID = agentID;
             m_scene = scene;
             m_module = module;

--- a/Source/OpenSim.Region.OptionalModules/ViewerSupport/GodNamesModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/ViewerSupport/GodNamesModule.cs
@@ -25,20 +25,24 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
-using log4net;
-using Nini.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.ViewerSupport
 {
     public class GodNamesModule : ISharedRegionModule
     {
         // Infrastructure
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         // Configuration
         private static bool m_enabled = false;
@@ -47,6 +51,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<GodNamesModule>>();
             IConfig moduleConfig = config.Configs["GodNames"];
 
             if (moduleConfig == null) {
@@ -54,18 +59,18 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
             }
 
             if (!moduleConfig.GetBoolean("Enabled", false)) {
-                m_log.Info("[GODNAMES]: Addon is disabled");
+                m_logger?.LogInformation("[GODNAMES]: Addon is disabled");
                 return;
             }
 
-            m_log.Info("[GODNAMES]: Enabled");
+            m_logger?.LogInformation("[GODNAMES]: Enabled");
             m_enabled = true;
             string conf_str = moduleConfig.GetString("FullNames", String.Empty);
             if (conf_str != String.Empty)
             {
                 foreach (string strl in conf_str.Split(',')) {
                     string strlan = strl.Trim(" \t".ToCharArray());
-                    m_log.DebugFormat("[GODNAMES]: Adding {0} as a God name", strlan);
+                    m_logger?.LogDebug("[GODNAMES]: Adding {0} as a God name", strlan);
                     m_fullNames.Add(strlan);
                 }
             }
@@ -75,7 +80,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
             {
                 foreach (string strl in conf_str.Split(',')) {
                     string strlan = strl.Trim(" \t".ToCharArray());
-                    m_log.DebugFormat("[GODNAMES]: Adding {0} as a God last name", strlan);
+                    m_logger?.LogDebug("[GODNAMES]: Adding {0} as a God last name", strlan);
                     m_lastNames.Add(strlan);
                 }
             }

--- a/Source/OpenSim.Region.OptionalModules/ViewerSupport/SimulatorFeaturesHelper.cs
+++ b/Source/OpenSim.Region.OptionalModules/ViewerSupport/SimulatorFeaturesHelper.cs
@@ -25,38 +25,28 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Collections.Generic;
-using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenMetaverse;
-using OpenMetaverse.StructuredData;
-using OpenSim;
-using OpenSim.Region;
-using OpenSim.Region.Framework;
+
 using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Framework;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
-//using OpenSim.Framework.Capabilities;
+
 using Nini.Config;
-using log4net;
-using OSDMap = OpenMetaverse.StructuredData.OSDMap;
-using TeleportFlags = OpenSim.Framework.Constants.TeleportFlags;
 
 namespace OpenSim.Region.OptionalModules.ViewerSupport
 {
     public class SimulatorFeaturesHelper
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private Scene m_scene;
 
         public SimulatorFeaturesHelper(Scene scene)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<SimulatorFeaturesHelper>>();
             m_scene = scene;
         }
 

--- a/Source/OpenSim.Region.OptionalModules/ViewerSupport/SpecialUIModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/ViewerSupport/SpecialUIModule.cs
@@ -25,14 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Server.Base;
 
 using Nini.Config;
-using log4net;
 
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 
@@ -40,7 +43,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 {
     public class SpecialUIModule : INonSharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         private const string VIEWER_SUPPORT_DIR = "ViewerSupport";
 
         private Scene m_scene;
@@ -60,6 +63,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<SpecialUIModule>>();
             IConfig moduleConfig = config.Configs["SpecialUIModule"];
             if (moduleConfig != null)
             {
@@ -67,7 +71,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
                 if (m_Enabled)
                 {
                     m_UserLevel = moduleConfig.GetInt("UserLevel", 0);
-                    m_log.Info("[SPECIAL UI]: SpecialUIModule enabled");
+                    m_logger?.LogInformation("[SPECIAL UI]: SpecialUIModule enabled");
                 }
 
             }
@@ -103,7 +107,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
 
         private void OnSimulatorFeaturesRequest(UUID agentID, ref OSDMap features)
         {
-            m_log.DebugFormat("[SPECIAL UI]: OnSimulatorFeaturesRequest in {0}", m_scene.RegionInfo.RegionName);
+            m_logger?.LogDebug("[SPECIAL UI]: OnSimulatorFeaturesRequest in {0}", m_scene.RegionInfo.RegionName);
             if (m_Helper.UserLevel(agentID) <= m_UserLevel)
             {
                 OSD extrasMap;
@@ -119,7 +123,7 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
                     specialUI["toolbar"] = OSDMap.FromString(s.ReadToEnd());
                     ((OSDMap)extrasMap)["special-ui"] = specialUI;
                 }
-                m_log.DebugFormat("[SPECIAL UI]: Sending panel_toolbar.xml in {0}", m_scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[SPECIAL UI]: Sending panel_toolbar.xml in {0}", m_scene.RegionInfo.RegionName);
 
                 if (Directory.Exists(Path.Combine(VIEWER_SUPPORT_DIR, "Floaters")))
                 {
@@ -136,11 +140,11 @@ namespace OpenSim.Region.OptionalModules.ViewerSupport
                         }
                     }
                     specialUI["floaters"] = floaters;
-                    m_log.DebugFormat("[SPECIAL UI]: Sending {0} floaters", n);
+                    m_logger?.LogDebug("[SPECIAL UI]: Sending {0} floaters", n);
                 }
             }
             else
-                m_log.DebugFormat("[SPECIAL UI]: NOT Sending panel_toolbar.xml in {0}", m_scene.RegionInfo.RegionName);
+                m_logger?.LogDebug("[SPECIAL UI]: NOT Sending panel_toolbar.xml in {0}", m_scene.RegionInfo.RegionName);
 
         }
 

--- a/Source/OpenSim.Region.OptionalModules/World/MoneyModule/SampleMoneyModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/World/MoneyModule/SampleMoneyModule.cs
@@ -27,19 +27,24 @@
 
 using System.Collections;
 using System.Net;
-using System.Reflection;
-using log4net;
-using Nini.Config;
-using Nwc.XmlRpc;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
+
 using OpenSim.Framework;
 using OpenSim.Framework.Servers;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
+
+using Nwc.XmlRpc;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.World.MoneyModule
 {
@@ -55,7 +60,7 @@ namespace OpenSim.Region.OptionalModules.World.MoneyModule
     /// </summary>
     public class SampleMoneyModule : IMoneyModule, ISharedRegionModule
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         /// <summary>
         /// Where Stipends come from and Fees go to.
@@ -123,6 +128,7 @@ namespace OpenSim.Region.OptionalModules.World.MoneyModule
         /// <param name="config">Configuration source.</param>
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<SampleMoneyModule>>();
             m_gConfig = config;
             ReadConfigAndPopulate();
         }
@@ -385,7 +391,7 @@ namespace OpenSim.Region.OptionalModules.World.MoneyModule
             }
             else
             {
-                m_log.ErrorFormat(
+                m_logger?.LogError(
                     "[MONEY]: Could not resolve user {0}",
                     agentID);
             }

--- a/Source/OpenSim.Region.OptionalModules/World/WorldView/WorldViewModule.cs
+++ b/Source/OpenSim.Region.OptionalModules/World/WorldView/WorldViewModule.cs
@@ -27,28 +27,32 @@
 
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Reflection;
-using log4net;
-using Nini.Config;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework.Servers;
+using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Server.Base;
+
+using Nini.Config;
 
 namespace OpenSim.Region.OptionalModules.World.WorldView
 {
     public class WorldViewModule : INonSharedRegionModule
     {
-        private static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
+        private static ILogger? m_logger;
 
         private bool m_Enabled = false;
         private IMapImageGenerator m_Generator;
 
         public void Initialise(IConfiguration config)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<WorldViewModule>>();
             IConfig moduleConfig = config.Configs["Modules"];
             if (moduleConfig == null)
                 return;
@@ -75,7 +79,7 @@ namespace OpenSim.Region.OptionalModules.World.WorldView
                 return;
             }
 
-            m_log.Info("[WORLDVIEW]: Configured and enabled");
+            m_logger?.LogInformation("[WORLDVIEW]: Configured and enabled");
 
             IHttpServer server = MainServer.GetHttpServer(0);
             server.AddStreamHandler(new WorldViewRequestHandler(this,

--- a/Source/OpenSim.Region.OptionalModules/World/WorldView/WorldViewRequestHandler.cs
+++ b/Source/OpenSim.Region.OptionalModules/World/WorldView/WorldViewRequestHandler.cs
@@ -25,26 +25,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Xml;
-
-using OpenSim.Framework;
-using OpenSim.Server.Base;
-using OpenSim.Framework.Servers.HttpServer;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using OpenMetaverse;
-using log4net;
+
+using OpenSim.Server.Base;
+using OpenSim.Framework.Servers.HttpServer;
 
 namespace OpenSim.Region.OptionalModules.World.WorldView
 {
     public class WorldViewRequestHandler : BaseStreamHandler
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         protected WorldViewModule m_WorldViewModule;
         protected Object m_RequestLock = new Object();
@@ -52,6 +45,7 @@ namespace OpenSim.Region.OptionalModules.World.WorldView
         public WorldViewRequestHandler(WorldViewModule fmodule, string rid)
                 : base("GET", "/worldview/" + rid)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<WorldViewRequestHandler>>();
             m_WorldViewModule = fmodule;
         }
 
@@ -79,7 +73,7 @@ namespace OpenSim.Region.OptionalModules.World.WorldView
             }
             catch (Exception e)
             {
-                m_log.Debug("[WORLDVIEW]: Exception: " + e.ToString());
+                m_logger?.LogDebug("[WORLDVIEW]: Exception: " + e.ToString());
             }
 
             return Array.Empty<byte>();

--- a/Source/OpenSim.Region.PhysicsModule.BulletS/BSConstraintCollection.cs
+++ b/Source/OpenSim.Region.PhysicsModule.BulletS/BSConstraintCollection.cs
@@ -24,17 +24,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
-using log4net;
-using OpenMetaverse;
+// using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+// using OpenSim.Server.Base;
 
 namespace OpenSim.Region.PhysicsModule.BulletS
 {
     public sealed class BSConstraintCollection : IDisposable
     {
-        // private static readonly ILog m_log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
         // private static readonly string LogHeader = "[CONSTRAINT COLLECTION]";
 
         delegate bool ConstraintAction(BSConstraint constrain);
@@ -44,6 +43,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
 
         public BSConstraintCollection(BulletWorld world)
         {
+            // m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<BSConstraintCollection>>();
             m_world = world;
             m_constraints = new List<BSConstraint>();
         }

--- a/Source/OpenSim.Region.PhysicsModule.BulletS/BSTerrainHeightmap.cs
+++ b/Source/OpenSim.Region.PhysicsModule.BulletS/BSTerrainHeightmap.cs
@@ -24,17 +24,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-using OpenSim.Framework;
-using OpenSim.Region.Framework;
-using OpenSim.Region.PhysicsModule.SharedBase;
-
-using Nini.Config;
-using log4net;
-
+using Microsoft.Extensions.Logging;
 using OpenMetaverse;
 
 namespace OpenSim.Region.PhysicsModule.BulletS
@@ -170,7 +161,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             catch
             {
                 // Sometimes they give us wonky values of X and Y. Give a warning and return something.
-                m_physicsScene.Logger.WarnFormat("{0} Bad request for terrain height. terrainBase={1}, pos={2}",
+                m_physicsScene.Logger.LogWarning("{0} Bad request for terrain height. terrainBase={1}, pos={2}",
                                     LogHeader, m_mapInfo.terrainRegionBase, pos);
                 ret = BSTerrainManager.HEIGHT_GETHEIGHT_RET;
             }

--- a/Source/OpenSim.Region.PhysicsModule.BulletS/BSTerrainMesh.cs
+++ b/Source/OpenSim.Region.PhysicsModule.BulletS/BSTerrainMesh.cs
@@ -24,18 +24,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using OpenSim.Framework;
-using OpenSim.Region.Framework;
-using OpenSim.Region.PhysicsModule.SharedBase;
-
-using Nini.Config;
-using log4net;
 
 using OpenMetaverse;
+
+using Microsoft.Extensions.Logging;
 
 namespace OpenSim.Region.PhysicsModule.BulletS
 {
@@ -98,7 +90,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             {
                 // DISASTER!!
                 m_physicsScene.DetailLog("{0},BSTerrainMesh.create,failedConversionOfHeightmap,id={1}", BSScene.DetailLogZero, ID);
-                m_physicsScene.Logger.ErrorFormat("{0} Failed conversion of heightmap to mesh! base={1}", LogHeader, TerrainBase);
+                m_physicsScene.Logger.LogError("{0} Failed conversion of heightmap to mesh! base={1}", LogHeader, TerrainBase);
                 // Something is very messed up and a crash is in our future.
                 return;
             }
@@ -111,7 +103,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             {
                 // DISASTER!!
                 m_physicsScene.DetailLog("{0},BSTerrainMesh.create,failedCreationOfShape,id={1}", BSScene.DetailLogZero, ID);
-                m_physicsScene.Logger.ErrorFormat("{0} Failed creation of terrain mesh! base={1}", LogHeader, TerrainBase);
+                m_physicsScene.Logger.LogError("{0} Failed creation of terrain mesh! base={1}", LogHeader, TerrainBase);
                 // Something is very messed up and a crash is in our future.
                 return;
             }
@@ -123,7 +115,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             if (!m_terrainBody.HasPhysicalBody)
             {
                 // DISASTER!!
-                m_physicsScene.Logger.ErrorFormat("{0} Failed creation of terrain body! base={1}", LogHeader, TerrainBase);
+                m_physicsScene.Logger.LogError("{0} Failed creation of terrain body! base={1}", LogHeader, TerrainBase);
                 // Something is very messed up and a crash is in our future.
                 return;
             }
@@ -184,7 +176,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             catch
             {
                 // Sometimes they give us wonky values of X and Y. Give a warning and return something.
-                m_physicsScene.Logger.WarnFormat("{0} Bad request for terrain height. terrainBase={1}, pos={2}",
+                m_physicsScene.Logger.LogWarning("{0} Bad request for terrain height. terrainBase={1}, pos={2}",
                                                     LogHeader, TerrainBase, pos);
                 ret = BSTerrainManager.HEIGHT_GETHEIGHT_RET;
             }
@@ -272,7 +264,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             catch (Exception e)
             {
                 if (physicsScene != null)
-                    physicsScene.Logger.ErrorFormat("{0} Failed conversion of heightmap to mesh. For={1}/{2}, e={3}",
+                    physicsScene.Logger.LogError("{0} Failed conversion of heightmap to mesh. For={1}/{2}, e={3}",
                                                     LogHeader, physicsScene.RegionName, extentBase, e);
             }
 
@@ -425,7 +417,7 @@ namespace OpenSim.Region.PhysicsModule.BulletS
             catch (Exception e)
             {
                 if (physicsScene != null)
-                    physicsScene.Logger.ErrorFormat("{0} Failed conversion of heightmap to mesh. For={1}/{2}, e={3}",
+                    physicsScene.Logger.LogError("{0} Failed conversion of heightmap to mesh. For={1}/{2}, e={3}",
                                                     LogHeader, physicsScene.RegionName, extentBase, e);
             }
 

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/ApiManager.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/ApiManager.cs
@@ -25,18 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Reflection;
-using log4net;
+// using Microsoft.Extensions.DependencyInjection;
+// using Microsoft.Extensions.Logging;
+
 using OpenSim.Region.ScriptEngine.Interfaces;
+// using OpenSim.Server.Base;
 
 namespace OpenSim.Region.ScriptEngine.Shared.Api
 {
     public class ApiManager
     {
-//        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
 
         private Dictionary<string,Type> m_Apis = new Dictionary<string,Type>();
 
@@ -63,7 +63,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
                 }
             }
 
-//            m_log.DebugFormat("[API MANAGER]: Found {0} apis", m_Apis.Keys.Count);
+//            m_logger.LogDebug("[API MANAGER]: Found {0} apis", m_Apis.Keys.Count);
 
             return new List<string>(m_Apis.Keys).ToArray();
         }

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/AsyncCommandManager.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/AsyncCommandManager.cs
@@ -25,20 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
-using OpenSim.Framework;
+
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.ScriptEngine.Interfaces;
-using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api.Plugins;
 using ScriptTimer=OpenSim.Region.ScriptEngine.Shared.Api.Plugins.ScriptTimer;
-using System.Reflection;
-using log4net;
+using OpenSim.Server.Base;
 
 namespace OpenSim.Region.ScriptEngine.Shared.Api
 {
@@ -47,7 +44,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
     /// </summary>
     public class AsyncCommandManager
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private static Thread cmdHandlerThread;
         private static int cmdHandlerThreadCycleSleepms;
@@ -144,6 +141,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public AsyncCommandManager(IScriptEngine _ScriptEngine)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<AsyncCommandManager>>();
             m_ScriptEngine = _ScriptEngine;
 
             // If there is more than one scene in the simulator or multiple script engines are used on the same region
@@ -237,7 +235,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
                 }
                 catch (Exception e)
                 {
-                    m_log.Error("[ASYNC COMMAND MANAGER]: Exception in command handler pass: ", e);
+                    m_logger?.LogError("[ASYNC COMMAND MANAGER]: Exception in command handler pass: ", e);
                 }
             }
         }

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/LSL_Api.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/LSL_Api.cs
@@ -25,12 +25,24 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using log4net;
-using Nini.Config;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenMetaverse.Assets;
 using OpenMetaverse.Packets;
 using OpenMetaverse.Rendering;
+
 using OpenSim.Framework;
 using OpenSim.Region.CoreModules.World.Land;
 using OpenSim.Region.Framework.Interfaces;
@@ -38,24 +50,13 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Scenes.Animation;
 using OpenSim.Region.Framework.Scenes.Scripting;
 using OpenSim.Region.Framework.Scenes.Serialization;
-using OpenSim.Region.PhysicsModules.SharedBase;
 using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared.Api.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
+using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.Connectors.Hypergrid;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
-using System.Drawing;
-using System.Globalization;
-using System.Reflection;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
+
 using AssetLandmark = OpenSim.Framework.AssetLandmark;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
@@ -70,7 +71,8 @@ using PresenceInfo = OpenSim.Services.Interfaces.PresenceInfo;
 using PrimType = OpenSim.Region.Framework.Scenes.PrimType;
 using RegionFlags = OpenSim.Framework.RegionFlags;
 using RegionInfo = OpenSim.Framework.RegionInfo;
-using System.Runtime.CompilerServices;
+
+using Nini.Config;
 
 #pragma warning disable IDE1006
 
@@ -81,7 +83,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
     /// </summary>
     public class LSL_Api : MarshalByRefObject, ILSL_Api, IScriptApi
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         private int m_llRequestAgentDataCacheTimeout;
         public int LlRequestAgentDataCacheTimeoutMs
@@ -386,6 +388,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public void Initialize(IScriptEngine scriptEngine, SceneObjectPart host, TaskInventoryItem item)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<LSL_Api>>();
             m_lastSayShoutCheck = DateTime.UtcNow;
 
             m_ScriptEngine = scriptEngine;
@@ -3484,7 +3487,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public virtual void llSleep(double sec)
         {
-//            m_log.Info("llSleep snoozing " + sec + "s.");
+//            m_logger?.LogInformation("llSleep snoozing " + sec + "s.");
 
             Sleep((int)(sec * 1000));
         }
@@ -15154,7 +15157,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
             if (ossl != null)
             {
                 ossl.CheckThreatLevel(ThreatLevel.High, "print");
-                m_log.Info("LSL print():" + str);
+                m_logger?.LogInformation("LSL print():" + str);
             }
         }
 

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/MOD_Api.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/MOD_Api.cs
@@ -25,23 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Reflection;
-using System.Collections;
-using System.Collections.Generic;
-using System.Threading;
-using log4net;
+// using Microsoft.Extensions.DependencyInjection;
+// using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
-using Nini.Config;
-using OpenSim;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.ScriptEngine.Shared;
-using OpenSim.Region.ScriptEngine.Shared.Api.Plugins;
 using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared.Api.Interfaces;
+// using OpenSim.Server.Base;
 
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
@@ -51,12 +46,14 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
+using Nini.Config;
+
 namespace OpenSim.Region.ScriptEngine.Shared.Api
 {
     [Serializable]
     public class MOD_Api : MarshalByRefObject, IMOD_Api, IScriptApi
     {
-//        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
 
         internal IScriptEngine m_ScriptEngine;
         internal SceneObjectPart m_host;
@@ -68,6 +65,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
         public void Initialize(
             IScriptEngine scriptEngine, SceneObjectPart host, TaskInventoryItem item)
         {
+            // m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<MOD_Api>>();
             m_ScriptEngine = scriptEngine;
             m_host = host;
             m_item = item;
@@ -121,7 +119,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
         /// <returns>string result of the invocation</returns>
         public void modInvokeN(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -136,7 +134,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_String modInvokeS(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -152,7 +150,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_Integer modInvokeI(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -168,7 +166,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_Float modInvokeF(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -184,7 +182,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_Key modInvokeK(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -200,7 +198,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_Vector modInvokeV(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -216,7 +214,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_Rotation modInvokeR(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -232,7 +230,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
 
         public LSL_List modInvokeL(string fname, params object[] parms)
         {
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),
@@ -299,7 +297,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
                 return "";
             }
 
-//            m_log.DebugFormat(
+//            m_logger?.LogDebug(
 //                "[MOD API]: Invoking dynamic function {0}, args '{1}' with {2} return type",
 //                fname,
 //                string.Join(",", Array.ConvertAll<object, string>(parms, o => o.ToString())),

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/Plugins/Listener.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/Plugins/Listener.cs
@@ -25,20 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using log4net;
 using OpenMetaverse;
 using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.Scripting.WorldComm;
-using OpenSim.Region.ScriptEngine.Interfaces;
-using OpenSim.Region.ScriptEngine.Shared;
-using OpenSim.Region.ScriptEngine.Shared.Api;
 
 namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class Listener
     {
-        // private static readonly ILog m_log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
 
         public AsyncCommandManager m_CmdManager;
 

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -25,12 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using OpenMetaverse;
+
 using OpenSim.Framework;
-//using log4net;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
@@ -38,7 +35,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class SensorRepeat
     {
-        //private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        // private static ILogger? m_logger;
 
         /// <summary>
         /// Used by one-off and repeated sensors
@@ -492,7 +489,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
 
             Action<ScenePresence> senseEntity = new(presence =>
             {
-                //m_log.DebugFormat(
+                //m_logger?.LogDebug(
                 //    "[SENSOR REPEAT]: Inspecting scene presence {0}, type {1} on sensor sweep for {2}, type {3}",
                 //    presence.Name, presence.PresenceType, ts.name, ts.type);
 
@@ -501,7 +498,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
                     INPC npcData = m_npcModule.GetNPC(presence.UUID, presence.Scene);
                     if (npcData is null || !npcData.SenseAsAgent)
                     {
-                        //m_log.DebugFormat(
+                        //m_logger?.LogDebug(
                         //    "[SENSOR REPEAT]: Discarding NPC {0} from agent sense sweep for script item id {1}",
                         //    presence.Name, ts.itemID);
                         return;
@@ -519,7 +516,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
                         INPC npcData = m_npcModule.GetNPC(presence.UUID, presence.Scene);
                         if (npcData is not null && npcData.SenseAsAgent)
                         {
-                            //m_log.DebugFormat(
+                            //m_logger?.LogDebug(
                             //    "[SENSOR REPEAT]: Discarding NPC {0} from non-agent sense sweep for script item id {1}",
                             //    presence.Name, ts.itemID);
                             return;

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Interfaces/IScriptEngine.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Interfaces/IScriptEngine.cs
@@ -25,17 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
 using System.Reflection;
-using OpenSim.Framework;
+
+using OpenMetaverse;
+
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
-using Amib.Threading;
-using log4net;
+
 using Nini.Config;
-using OpenMetaverse;
 
 namespace OpenSim.Region.ScriptEngine.Interfaces
 {

--- a/Source/OpenSim.Region.ScriptEngine.Shared/Interfaces/IScriptInstance.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Interfaces/IScriptInstance.cs
@@ -25,17 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Threading;
 using System.Diagnostics;
+
 using OpenMetaverse;
-using log4net;
+
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.ScriptEngine.Shared;
-using OpenSim.Region.ScriptEngine.Interfaces;
 
 namespace OpenSim.Region.ScriptEngine.Interfaces
 {

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMREvents.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMREvents.cs
@@ -25,17 +25,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
-using OpenSim.Region.ScriptEngine.Interfaces;
-using log4net;
 
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
@@ -57,7 +52,7 @@ namespace OpenSim.Region.ScriptEngine.Yengine
 
         private void InitEvents()
         {
-            m_log.Info("[YEngine] Hooking up to server events");
+            m_logger?.LogInformation("[YEngine] Hooking up to server events");
             EventManager eManager = this.World.EventManager;
             eManager.OnAttach += attach;
             eManager.OnObjectGrab += touch_start;

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstBackend.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstBackend.cs
@@ -25,14 +25,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Threading;
-using System.Collections.Generic;
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api;
-using log4net;
 
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCapture.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCapture.cs
@@ -25,13 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.IO;
 using System.Xml;
 using OpenSim.Framework;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api;
-using log4net;
 
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCtor.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCtor.cs
@@ -25,24 +25,20 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Threading;
-using System.Reflection;
 using System.Collections;
-using System.Collections.Generic;
-using System.Security.Policy;
-using System.IO;
 using System.Xml;
 using System.Text;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api;
-using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
-using OpenSim.Region.ScriptEngine.Yengine;
-using OpenSim.Region.Framework.Scenes;
-using log4net;
+using OpenSim.Server.Base;
 
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
@@ -74,6 +70,7 @@ namespace OpenSim.Region.ScriptEngine.Yengine
         public void Initialize(Yengine engine, string scriptBasePath,
                                int stackSize, int heapSize, ArrayList errors)
         {
+            m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<XMRInstance>>();
             if(stackSize < 16384)
                 stackSize = 16384;
             if(heapSize < 16384)
@@ -299,7 +296,7 @@ namespace OpenSim.Region.ScriptEngine.Yengine
          */
         private string FetchSource(string cameFrom)
         {
-            m_log.Debug("[YEngine]: fetching source " + cameFrom);
+            m_logger?.LogDebug("[YEngine]: fetching source " + cameFrom);
             if(!cameFrom.StartsWith("asset://"))
                 throw new Exception("unable to retrieve source from " + cameFrom);
 
@@ -1057,8 +1054,8 @@ namespace OpenSim.Region.ScriptEngine.Yengine
                 }
                 catch(Exception e)
                 {
-                    m_log.Warn("[YEngine]: RestoreDetectParams bad XML: " + detxml.ToString());
-                    m_log.Warn("[YEngine]: ... " + e.ToString());
+                    m_logger?.LogWarning("[YEngine]: RestoreDetectParams bad XML: " + detxml.ToString());
+                    m_logger?.LogWarning("[YEngine]: ... " + e.ToString());
                 }
             }
 

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstMain.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstMain.cs
@@ -25,17 +25,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Threading;
-using System.Reflection;
 using System.Collections;
-using System.Collections.Generic;
+
+using Microsoft.Extensions.Logging;
+
 using OpenMetaverse;
+
 using OpenSim.Framework;
 using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.Framework.Scenes;
-using log4net;
 
 // This class exists in the main app domain
 //
@@ -85,8 +84,7 @@ namespace OpenSim.Region.ScriptEngine.Yengine
         public static readonly DetectParams[] zeroDetectParams = new DetectParams[0];
         public static readonly object[] zeroObjectArray = new object[0];
 
-        public static readonly ILog m_log =
-            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static ILogger? m_logger;
 
         public XMRInstance m_NextInst;  // used by XMRInstQueue
         public XMRInstance m_PrevInst;

--- a/Source/OpenSim.Server.MoneyServer/Program.cs
+++ b/Source/OpenSim.Server.MoneyServer/Program.cs
@@ -26,22 +26,22 @@
  */
 
 
-using log4net.Config;
+using System.CommandLine;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
-using System.Collections.Generic;
-using OpenSim.Data;
-using Autofac.Extensions.DependencyInjection;
-using Autofac;
-using System.CommandLine;
-using OpenSim.Server.Common;
-using OpenSim.Framework.Servers;
-using OpenSim.Server.Base;
+
 using OpenSim.Framework.Console;
 using OpenSim.Framework;
-using ConfigurationSubstitution;
 using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Server.Base;
+using OpenSim.Server.Common;
+
+using ConfigurationSubstitution;
+
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
 
 namespace OpenSim.Server.MoneyServer
 {

--- a/Source/OpenSim.Server.RegionServer/Program.cs
+++ b/Source/OpenSim.Server.RegionServer/Program.cs
@@ -27,24 +27,20 @@
 
 using System.CommandLine;
 
-using log4net.Config;
-using Nini.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
+
 using Autofac.Extensions.DependencyInjection;
 using Autofac;
 
 using OpenSim.ApplicationPlugins.LoadRegions;
 using OpenSim.ApplicationPlugins.RegionModulesController;
 using OpenSim.ApplicationPlugins.RemoteController;
-
+using OpenSim.Groups;
 using OpenSim.Region.OptionalModules;
 using OpenSim.Region.CoreModules;
 using OpenSim.Region.Framework;
-
-using OpenSim.Services.SimulationService;
-using OpenSim.Services.EstateService;
 using OpenSim.Region.PhysicsModule.BasicPhysics;
 using OpenSim.Region.ClientStack.LindenUDP;
 using OpenSim.Region.ClientStack.Linden;
@@ -53,14 +49,10 @@ using OpenSim.Region.PhysicsModule.POS;
 using OpenSim.Region.PhysicsModule.BulletS;
 using OpenSim.Region.PhysicsModule.ubOde;
 using OpenSim.Region.PhysicsModule.ubOdeMeshing;
-using OpenSim.Region.CoreModules.Framework.Search;
-using OpenSimSearch.Modules.OpenSearch;
-using OpenSim.Groups;
-using Gloebit.GloebitMoneyModule;
 using OpenSim.Region.ScriptEngine.Yengine;
 using OpenSim.Server.Common;
-using ConfigurationSubstitution;
 
+using ConfigurationSubstitution;
 
 namespace OpenSim.Server.RegionServer
 {


### PR DESCRIPTION
More of converting log4net to Microsoft.Extensions.Logging.
Added a reference to the IServiceProvider into OpenSimServer which is the base class created by each of the services. In the individual modules, I've added a 
         private static ILogger? m_logger
to replace the static initialization with log4net. Then created a logger instance in the constructor/initializer so the classes begin with a
      m_logger ??= OpenSimServer.Instance.ServiceProvider.GetRequiredService<ILogger<CLASSNAME>>();
Then replaced all the references to m_log to m_logger and the proper method 
So, if the individual class is ever DI'ed, that initial assignment would be replaced with the logger passed in by DI.
